### PR TITLE
Declarative approach to implement API calls

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -33,12 +33,15 @@ jobs:
         go get golang.org/x/lint/golint
         go get github.com/mattn/goveralls
         go get github.com/go-playground/overalls
-        curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
 
     - name: go get deps
       run: |
-        cd $(go env GOPATH)/src/github.com/${{ github.repository }}
-        dep ensure
+        cd github.com/${{ github.repository }}/...
+        go get -v -t -d
+        if [ -f Gopkg.toml ]; then
+          curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
+          dep ensure
+        fi
 
     - name: go build
       run: go build -v github.com/${{ github.repository }}/...

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -30,6 +30,7 @@ jobs:
 
     - name: go get tools
       run: |
+        curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
         go get golang.org/x/lint/golint
         go get github.com/mattn/goveralls
         go get github.com/go-playground/overalls
@@ -37,10 +38,7 @@ jobs:
     - name: go get deps
       run: |
         cd $(go env GOPATH)/src/github.com/${{ github.repository }}
-        if [ -f Gopkg.toml ]; then
-            curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
-            dep ensure
-        fi
+        dep ensure
 
     - name: go build
       run: go build -v github.com/${{ github.repository }}/...

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -36,12 +36,7 @@ jobs:
 
     - name: go get deps
       run: |
-        cd github.com/${{ github.repository }}/...
-        go get -v -t -d
-        if [ -f Gopkg.toml ]; then
-          curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
-          dep ensure
-        fi
+        go get -v -t -d github.com/${{ github.repository }}/...
 
     - name: go build
       run: go build -v github.com/${{ github.repository }}/...

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -51,6 +51,8 @@ jobs:
         ls $(go env GOPATH)/src/github.com/${{ github.repository }}/
         echo "--"
         ls $(go env GOPATH)/src/github.com/${{ github.repository }}/api
+        echo "--"
+        ls $(go env GOPATH)/src/github.com/fogfish/privx-sdk-go/api
         $(go env GOPATH)/bin/goveralls -coverprofile=$(go env GOPATH)/src/github.com/${{ github.repository }}/overalls.coverprofile -service=github
 
     - name: go vet

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -17,16 +17,16 @@ jobs:
         go-version: 1.14
       id: go
 
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2
+      with:
+        path: src/github.com/${{ github.repository }}
+
     - name: fix GOPATH
       run: |
         echo "##[set-env name=GOPATH;]$(dirname $GITHUB_WORKSPACE)"
         echo "##[add-path]$(dirname $GITHUB_WORKSPACE)/bin"
       shell: bash
-
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v2
-      with:
-        path: ../src/github.com/${{ github.repository }}
 
     - name: go get tools
       run: |

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
       with:
-        path: ./src/github.com/${{ github.repository }}
+        path: $(go env GOPATH)/src/github.com/${{ github.repository }}
 
     - name: go get tools
       run: |

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -30,10 +30,10 @@ jobs:
 
     - name: go get tools
       run: |
-        curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
         go get golang.org/x/lint/golint
         go get github.com/mattn/goveralls
         go get github.com/go-playground/overalls
+        curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
 
     - name: go get deps
       run: |

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -20,10 +20,11 @@ jobs:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
       with:
-        path: $(go env GOPATH)/src/github.com/${{ github.repository }}
+        path: ./src/github.com/${{ github.repository }}
 
     - name: go get tools
       run: |
+        go env
         go get golang.org/x/lint/golint
         go get github.com/mattn/goveralls
         go get github.com/go-playground/overalls

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -17,16 +17,16 @@ jobs:
         go-version: 1.14
       id: go
 
+    - name: fix GOPATH
+      run: |
+        echo "##[set-env name=GOPATH;]$GITHUB_WORKSPACE"
+        echo "##[add-path]$GITHUB_WORKSPACE/bin"
+      shell: bash
+
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
       with:
         path: src/github.com/${{ github.repository }}
-
-    - name: fix GOPATH
-      run: |
-        echo "##[set-env name=GOPATH;]$(dirname $GITHUB_WORKSPACE)"
-        echo "##[add-path]$(dirname $GITHUB_WORKSPACE)/bin"
-      shell: bash
 
     - name: go get tools
       run: |

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -30,13 +30,13 @@ jobs:
 
     - name: go get tools
       run: |
-        go env
         go get golang.org/x/lint/golint
         go get github.com/mattn/goveralls
         go get github.com/go-playground/overalls
 
     - name: go get deps
       run: |
+        cd $(go env GOPATH)/src/github.com/${{ github.repository }}
         if [ -f Gopkg.toml ]; then
             curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
             dep ensure

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -30,7 +30,6 @@ jobs:
 
     - name: go get deps
       run: |
-        go get -v -t -d github.com/${{ github.repository }}/...
         if [ -f Gopkg.toml ]; then
             curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
             dep ensure
@@ -51,8 +50,6 @@ jobs:
         ls $(go env GOPATH)/src/github.com/${{ github.repository }}/
         echo "--"
         ls $(go env GOPATH)/src/github.com/${{ github.repository }}/api
-        echo "--"
-        ls $(go env GOPATH)/src/github.com/fogfish/privx-sdk-go/api
         $(go env GOPATH)/bin/goveralls -coverprofile=$(go env GOPATH)/src/github.com/${{ github.repository }}/overalls.coverprofile -service=github
 
     - name: go vet

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -48,16 +48,12 @@ jobs:
       env:
         COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        $(go env GOPATH)/bin/overalls -project=github.com/${{ github.repository }}
-        echo "--"
-        ls $(go env GOPATH)/src/github.com/${{ github.repository }}/
-        echo "--"
-        ls $(go env GOPATH)/src/github.com/${{ github.repository }}/api
-        $(go env GOPATH)/bin/goveralls -coverprofile=$(go env GOPATH)/src/github.com/${{ github.repository }}/overalls.coverprofile -service=github
+        overalls -project=github.com/${{ github.repository }}
+        goveralls -coverprofile=$(go env GOPATH)/src/github.com/${{ github.repository }}/overalls.coverprofile -service=github
 
     - name: go vet
       run: go vet github.com/${{ github.repository }}/...
 
     - name: golint
       run: |
-        $(go env GOPATH)/bin/golint -set_exit_status github.com/${{ github.repository }}/...
+        golint -set_exit_status github.com/${{ github.repository }}/...

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -17,10 +17,16 @@ jobs:
         go-version: 1.14
       id: go
 
+    - name: fix GOPATH
+      run: |
+        echo "##[set-env name=GOPATH;]$(dirname $GITHUB_WORKSPACE)"
+        echo "##[add-path]$(dirname $GITHUB_WORKSPACE)/bin"
+      shell: bash
+
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
       with:
-        path: /home/runner/go/src/github.com/${{ github.repository }}
+        path: ./src/github.com/${{ github.repository }}
 
     - name: go get tools
       run: |

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
       with:
-        path: ./src/github.com/${{ github.repository }}
+        path: src/github.com/${{ github.repository }}
 
     - name: go get tools
       run: |

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -47,6 +47,10 @@ jobs:
         COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         $(go env GOPATH)/bin/overalls -project=github.com/${{ github.repository }}
+        echo "--"
+        ls $(go env GOPATH)/src/github.com/${{ github.repository }}/
+        echo "--"
+        ls $(go env GOPATH)/src/github.com/${{ github.repository }}/api
         $(go env GOPATH)/bin/goveralls -coverprofile=$(go env GOPATH)/src/github.com/${{ github.repository }}/overalls.coverprofile -service=github
 
     - name: go vet

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
       with:
-        path: ./src/github.com/${{ github.repository }}
+        path: /home/runner/go/src/github.com/${{ github.repository }}
 
     - name: go get tools
       run: |

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
       with:
-        path: src/github.com/${{ github.repository }}
+        path: ../src/github.com/${{ github.repository }}
 
     - name: go get tools
       run: |

--- a/api/client.go
+++ b/api/client.go
@@ -131,6 +131,7 @@ type CURL struct {
 	fail    error
 }
 
+// URL creates URL connector
 func (client *Client) URL(method, url string) *CURL {
 	return &CURL{
 		client:  client,
@@ -150,7 +151,7 @@ func (client *Client) Put(templateURL string, args ...interface{}) *CURL {
 	return client.URL(http.MethodPut, fmt.Sprintf(templateURL, args...))
 }
 
-//
+// Send payload to destination URL.
 func (curl *CURL) Send(data interface{}) *CURL {
 	return curl.encodeJSON(data)
 }
@@ -167,7 +168,7 @@ func (curl *CURL) encodeJSON(data interface{}) *CURL {
 	return curl
 }
 
-//
+// Recv payload from target URL.
 func (curl *CURL) Recv(data interface{}) error {
 	curl = curl.unsafeIO()
 
@@ -193,7 +194,7 @@ func (curl *CURL) Recv(data interface{}) error {
 	return nil
 }
 
-//
+// RecvStatus payload from target URL and discards it.
 func (curl *CURL) RecvStatus() error {
 	curl = curl.unsafeIO()
 

--- a/api/client.go
+++ b/api/client.go
@@ -28,8 +28,7 @@ type Connector interface {
 
 // Client is an SDK client instance.
 type Client struct {
-	auth oauth.Provider
-	// TODO: rename endpoint -> host
+	auth     oauth.Provider
 	endpoint string
 	http     *http.Client
 }
@@ -137,7 +136,7 @@ func (client *Client) URL(method, url string) *CURL {
 	return &CURL{
 		client:  client,
 		method:  method,
-		url:     fmt.Sprintf("%s/%s", client.endpoint, url),
+		url:     client.endpoint + url,
 		payload: bytes.NewBuffer(nil),
 	}
 }

--- a/api/client.go
+++ b/api/client.go
@@ -131,7 +131,6 @@ type CURL struct {
 	fail    error
 }
 
-// URL creates URL connector
 func (client *Client) URL(method, url string) *CURL {
 	return &CURL{
 		client:  client,

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -21,7 +21,7 @@ type MockAccess struct {
 	string
 }
 
-func (idp MockIdP) Token() (string, error) {
+func (idp MockAccess) Token() (string, error) {
 	return idp.string, nil
 }
 

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -1,0 +1,84 @@
+//
+// Copyright (c) 2020 SSH Communications Security Inc.
+//
+// All rights reserved.
+//
+
+package api_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/SSHcom/privx-sdk-go/api"
+)
+
+//
+type MockIdP struct {
+	string
+}
+
+func (idp MockIdP) Token() (string, error) {
+	return idp.string, nil
+}
+
+var idp = api.IdP(MockIdP{"trusted"})
+
+func TestRecv(t *testing.T) {
+	ts := mock()
+	defer ts.Close()
+
+	var data struct {
+		ID string `json:"id"`
+	}
+
+	err := api.NewClient(idp, api.Endpoint(ts.URL)).
+		Get("/").
+		Recv(&data)
+
+	if err != nil {
+		t.Errorf("client fails: %w", err)
+	}
+
+	if data.ID != "trusted" {
+		t.Errorf("unexpected response: %v", data)
+	}
+}
+
+func TestRecvNoIdP(t *testing.T) {
+	ts := mock()
+	defer ts.Close()
+
+	var data struct {
+		ID string `json:"id"`
+	}
+
+	err := api.NewClient(api.Endpoint(ts.URL)).
+		Get("/").
+		Recv(&data)
+
+	if err != nil {
+		t.Errorf("client fails: %w", err)
+	}
+
+	if data.ID != "untrusted" {
+		t.Errorf("unexpected response: %v", data)
+	}
+}
+
+//
+func mock() *httptest.Server {
+	return httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch {
+			case r.Header.Get("Authorization") == "Bearer trusted":
+				w.Header().Add("Content-Type", "application/json")
+				w.Write([]byte(`{"id": "trusted"}`))
+			default:
+				w.Header().Add("Content-Type", "application/json")
+				w.Write([]byte(`{"id": "untrusted"}`))
+			}
+		}),
+	)
+}

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 //
-type MockIdP struct {
+type MockAccess struct {
 	string
 }
 
@@ -25,7 +25,7 @@ func (idp MockIdP) Token() (string, error) {
 	return idp.string, nil
 }
 
-var access = api.AccessToken(MockIdP{"trusted"})
+var access = api.AccessToken(MockAccess{"trusted"})
 
 func TestGet(t *testing.T) {
 	ts := mockStatus()

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -23,7 +23,13 @@ func (idp MockIdP) Token() (string, error) {
 	return idp.string, nil
 }
 
-var idp = api.IdP(MockIdP{"trusted"})
+var access = api.AccessToken(MockIdP{"trusted"})
+
+// TODO:
+//  - template
+//  - send
+//  - error
+//  - bad format
 
 func TestRecv(t *testing.T) {
 	ts := mock()
@@ -33,7 +39,7 @@ func TestRecv(t *testing.T) {
 		ID string `json:"id"`
 	}
 
-	err := api.NewClient(idp, api.Endpoint(ts.URL)).
+	err := api.NewClient(access, api.Endpoint(ts.URL)).
 		Get("/").
 		Recv(&data)
 

--- a/api/rolestore/client.go
+++ b/api/rolestore/client.go
@@ -18,7 +18,7 @@ import (
 )
 
 type Client struct {
-	api *api.Client
+	*api.Client
 }
 
 type usersResult struct {
@@ -32,9 +32,7 @@ type rolesResult struct {
 }
 
 func NewClient(api *api.Client) (*Client, error) {
-	return &Client{
-		api: api,
-	}, nil
+	return &Client{api}, nil
 }
 
 func (store *Client) SearchUsers(keywords, source string) ([]*User, error) {
@@ -77,35 +75,10 @@ func (store *Client) SearchUsers(keywords, source string) ([]*User, error) {
 	return result.Items, nil
 }
 
-func (store *Client) GetUser(id string) (*User, error) {
-	url := fmt.Sprintf("%s/role-store/api/v1/users/%s",
-		store.api.Endpoint(), url.PathEscape(id))
-	req, err := http.NewRequest(http.MethodGet, url, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	resp, err := store.api.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	body, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return nil, err
-	}
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("HTTP error: %s", resp.Status)
-	}
-
-	result := new(User)
-	err = json.Unmarshal(body, result)
-	if err != nil {
-		return nil, err
-	}
-
-	return result, nil
+func (store *Client) GetUser(id string) (user *User, err error) {
+	url := fmt.Sprintf("/role-store/api/v1/users/%s", url.PathEscape(id))
+	err = store.Get(url).Recv(user)
+	return
 }
 
 func (store *Client) GetUserRoles(id string) ([]*Role, error) {

--- a/api/vault/vault.go
+++ b/api/vault/vault.go
@@ -7,10 +7,6 @@
 package vault
 
 import (
-	"encoding/json"
-	"fmt"
-	"io/ioutil"
-	"net/http"
 	"net/url"
 
 	"github.com/SSHcom/privx-sdk-go/api"
@@ -19,43 +15,19 @@ import (
 type Bag map[string]interface{}
 
 type Client struct {
-	api *api.Client
+	api api.Connector
 }
 
-func NewClient(api *api.Client) (*Client, error) {
+func NewClient(api api.Connector) (*Client, error) {
 	return &Client{
 		api: api,
 	}, nil
 }
 
-func (vault *Client) Get(name string) (Bag, error) {
-	secretURL := fmt.Sprintf("%s/vault/api/v1/secrets/%s",
-		vault.api.Endpoint(),
-		url.PathEscape(name))
-	req, err := http.NewRequest(http.MethodGet, secretURL, nil)
-	if err != nil {
-		return nil, err
-	}
+func (vault *Client) Get(name string) (bag Bag, err error) {
+	err = vault.api.
+		Get("/vault/api/v1/secrets/%s", url.PathEscape(name)).
+		Recv(&bag)
 
-	resp, err := vault.api.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	body, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return nil, err
-	}
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("HTTP error: %s", resp.Status)
-	}
-
-	bag := new(Bag)
-	err = json.Unmarshal(body, bag)
-	if err != nil {
-		return nil, err
-	}
-
-	return *bag, nil
+	return
 }

--- a/oauth/client.go
+++ b/oauth/client.go
@@ -25,6 +25,11 @@ import (
 	"github.com/SSHcom/privx-sdk-go/pkce"
 )
 
+// Provider is a source for access token to api client
+type Provider interface {
+	Token() (string, error)
+}
+
 const (
 	UserAgent = "privx-sdk-go"
 )


### PR DESCRIPTION
__WHAT__

1. Interfaces

SDK defines interface for core concepts 
* `oauth.Provider`
* `api.Connetor`

Interfaces helps to mock and test SDK implementation

2. Declarative HTTP I/O

The proposal is inspired by my declarative HTTP libraries

```
api.Connector -[ creates ]-> *CURL

CURL implements
func (curl *CURL) Send(data interface{}) *CURL
func (curl *CURL) Recv(data interface{}) error
func (curl *CURL) RecvStatus() error
```

Example of usage

```
err = vault.api.
  Get("/vault/api/v1/secrets/%s", url.PathEscape(name)).
  Recv(&bag)
```

3. Unit testing for client 
 

__NOTE__

* api.Client requires a lot of refactoring but it happens in future PR. We need to unlock boilerplate less api development asap.
* We need to agree about type-safe approach across api methods but it happens in later as well 
