### PR TITLE
Improve semantic of API's return values

### DIFF
--- a/api/auth/client.go
+++ b/api/auth/client.go
@@ -1,0 +1,30 @@
+//
+// Copyright (c) 2020 SSH Communications Security Inc.
+//
+// All rights reserved.
+//
+
+package auth
+
+import (
+	"github.com/SSHcom/privx-sdk-go/restapi"
+)
+
+// Client is a authorizer client instance.
+type Client struct {
+	api restapi.Connector
+}
+
+// New creates a new authorizer client instance
+func New(api restapi.Connector) *Client {
+	return &Client{api: api}
+}
+
+// RootCertificate fetches
+func (auth *Client) RootCertificate() (ca []CA, err error) {
+	_, err = auth.api.
+		URL("/authorizer/api/v1/cas").
+		Get(&ca)
+
+	return
+}

--- a/api/auth/model.go
+++ b/api/auth/model.go
@@ -1,0 +1,18 @@
+//
+// Copyright (c) 2020 SSH Communications Security Inc.
+//
+// All rights reserved.
+//
+
+package auth
+
+//
+// CA is root certificate representation
+type CA struct {
+	ID        string `json:"id"`
+	GroupID   string `json:"group_id"`
+	Type      string `json:"type"`
+	Size      int    `json:"size"`
+	PublicKey string `json:"public_key"`
+	X509      string `json:"x509_certificate"`
+}


### PR DESCRIPTION
Use pointers to return results of API operation. The pointers makes return values look-like either data type.

```
// good, returned values are pointers
func A() (*User, error)
func B() ([]User, error)

// bad
func A() (User, error)
func B() ([]*User, error)
```