### PR TITLE
add a new API endpoint, get secrets from vault

### DIFF
--- a/api/vault/model.go
+++ b/api/vault/model.go
@@ -12,6 +12,12 @@ import (
 	"github.com/SSHcom/privx-sdk-go/api/rolestore"
 )
 
+// Params struct for pagination queries.
+type Params struct {
+	Offset string `json:"offset,omitempty"`
+	Limit  string `json:"limit,omitempty"`
+}
+
 // Secret contains PrivX metadata about secret and its vault
 type Secret struct {
 	ID         string              `json:"name"`

--- a/api/vault/vault.go
+++ b/api/vault/vault.go
@@ -18,14 +18,35 @@ type Vault struct {
 	api restapi.Connector
 }
 
+type secretResult struct {
+	Count int      `json:"count"`
+	Items []Secret `json:"items"`
+}
+
 // New creates a new Vault client instance, using the argument
 // SDK API client.
 func New(api restapi.Connector) *Vault {
 	return &Vault{api: api}
 }
 
-// Get gets the content of the argument secret.
-func (vault *Vault) Get(name string) (bag *Secret, err error) {
+// Secrets returns secrets client has access to
+func (vault *Vault) Secrets(offset, limit string) ([]Secret, error) {
+	result := secretResult{}
+	filters := Params{
+		Offset: offset,
+		Limit:  limit,
+	}
+
+	_, err := vault.api.
+		URL("/vault/api/v1/secrets").
+		Query(&filters).
+		Get(&result)
+
+	return result.Items, err
+}
+
+// Secret gets the content of the argument secret.
+func (vault *Vault) Secret(name string) (bag *Secret, err error) {
 	bag = new(Secret)
 	_, err = vault.api.
 		URL("/vault/api/v1/secrets/%s", url.PathEscape(name)).


### PR DESCRIPTION
New endpoint added to vault: GET `/vault/api/v1/secrets`
I also renamed the existing `Get` function to `Secret`, according to go's best practice as discussed in a previus pull request.