### PR TITLE
add a new API endpoint, get secret metadata

### DIFF
--- a/api/vault/vault.go
+++ b/api/vault/vault.go
@@ -29,6 +29,17 @@ func New(api restapi.Connector) *Vault {
 	return &Vault{api: api}
 }
 
+// SecretMetadata returns secret metadata
+func (vault *Vault) SecretMetadata(name string) (metadata *Secret, err error) {
+	metadata = new(Secret)
+
+	_, err = vault.api.
+		URL("/vault/api/v1/metadata/secrets/%s", url.PathEscape(name)).
+		Get(metadata)
+
+	return
+}
+
 // Secrets returns secrets client has access to
 func (vault *Vault) Secrets(offset, limit string) ([]Secret, error) {
 	result := secretResult{}


### PR DESCRIPTION
New endpoint added to vault: GET `/vault/api/v1/metadata/secrets/{name}`