### PR TITLE
add a new API endpoint, get host tags

### DIFF
--- a/api/hoststore/client.go
+++ b/api/hoststore/client.go
@@ -22,10 +22,33 @@ type hostResult struct {
 	Items []Host `json:"items"`
 }
 
+type tagsResult struct {
+	Count int      `json:"count"`
+	Items []string `json:"items"`
+}
+
 // New creates a new host-store client instance
 // See http://apispecs.ssh.com/#swagger-ui-4 for details about api
 func New(api restapi.Connector) *HostStore {
 	return &HostStore{api: api}
+}
+
+// HostTags returns hosts tags
+func (store *HostStore) HostTags(offset, limit, sortdir, query string) ([]string, error) {
+	result := tagsResult{}
+	filters := Params{
+		Offset:  offset,
+		Limit:   limit,
+		Sortdir: sortdir,
+		Query:   query,
+	}
+
+	_, err := store.api.
+		URL("/host-store/api/v1/hosts/tags").
+		Query(&filters).
+		Get(&result)
+
+	return result.Items, err
 }
 
 // UpdateDeployStatus update host to be deployable or undeployable

--- a/api/hoststore/model.go
+++ b/api/hoststore/model.go
@@ -39,6 +39,7 @@ type Params struct {
 	Sortdir string `json:"sortdir,omitempty"`
 	Sortkey string `json:"sortkey,omitempty"`
 	Filter  string `json:"filter,omitempty"`
+	Query   string `json:"query,omitempty"`
 }
 
 // Service specify the service available on target host


### PR DESCRIPTION
New endpoint added to host store: GET `/host-store/api/v1/hosts/tags`