### PR TITLE
add a new API endpoint, get default service options

### DIFF
--- a/api/hoststore/client.go
+++ b/api/hoststore/client.go
@@ -27,11 +27,6 @@ type tagsResult struct {
 	Items []string `json:"items"`
 }
 
-type serviceResult struct {
-	Count int                   `json:"count"`
-	Items DefaultServiceOptions `json:"items"`
-}
-
 // New creates a new host-store client instance
 // See http://apispecs.ssh.com/#swagger-ui-4 for details about api
 func New(api restapi.Connector) *HostStore {
@@ -39,14 +34,14 @@ func New(api restapi.Connector) *HostStore {
 }
 
 // ServiceOptions returns default serivce options
-func (store *HostStore) ServiceOptions() (DefaultServiceOptions, error) {
-	result := serviceResult{}
+func (store *HostStore) ServiceOptions() (options *DefaultServiceOptions, err error) {
+	options = new(DefaultServiceOptions)
 
-	_, err := store.api.
+	_, err = store.api.
 		URL("/host-store/api/v1/settings/default_service_options").
-		Get(&result)
+		Get(options)
 
-	return result.Items, err
+	return
 }
 
 // HostTags returns hosts tags

--- a/api/hoststore/client.go
+++ b/api/hoststore/client.go
@@ -27,10 +27,26 @@ type tagsResult struct {
 	Items []string `json:"items"`
 }
 
+type serviceResult struct {
+	Count int                   `json:"count"`
+	Items DefaultServiceOptions `json:"items"`
+}
+
 // New creates a new host-store client instance
 // See http://apispecs.ssh.com/#swagger-ui-4 for details about api
 func New(api restapi.Connector) *HostStore {
 	return &HostStore{api: api}
+}
+
+// ServiceOptions returns default serivce options
+func (store *HostStore) ServiceOptions() (DefaultServiceOptions, error) {
+	result := serviceResult{}
+
+	_, err := store.api.
+		URL("/host-store/api/v1/settings/default_service_options").
+		Get(&result)
+
+	return result.Items, err
 }
 
 // HostTags returns hosts tags

--- a/api/hoststore/model.go
+++ b/api/hoststore/model.go
@@ -106,6 +106,37 @@ type Host struct {
 	Status              []Status       `json:"status,omitempty"`
 }
 
+// SSHService default options
+type SSHService struct {
+	Shell        bool `json:"shell"`
+	FileTransfer bool `json:"file_transfer"`
+	Exec         bool `json:"exec"`
+	Tunnels      bool `json:"tunnels"`
+	Xeleven      bool `json:"x11"`
+	Other        bool `json:"other"`
+}
+
+// RDPService default options
+type RDPService struct {
+	FileTransfer bool `json:"file_transfer"`
+	Audio        bool `json:"audio"`
+	Clipboard    bool `json:"clipboard"`
+}
+
+// WebService default options
+type WebService struct {
+	FileTransfer bool `json:"file_transfer"`
+	Audio        bool `json:"audio"`
+	Clipboard    bool `json:"clipboard"`
+}
+
+// ServiceOptions default service options
+type DefaultServiceOptions struct {
+	SSH SSHService `json:"ssh"`
+	RDP RDPService `json:"rdp"`
+	Web WebService `json:"web"`
+}
+
 // Service creates a corresponding service definition
 //   hosts.SSH.Service(...)
 func (scheme Scheme) Service(addr Address, port int) Service {

--- a/api/hoststore/model.go
+++ b/api/hoststore/model.go
@@ -130,7 +130,7 @@ type WebService struct {
 	Clipboard    bool `json:"clipboard"`
 }
 
-// ServiceOptions default service options
+// DefaultServiceOptions default service options
 type DefaultServiceOptions struct {
 	SSH SSHService `json:"ssh"`
 	RDP RDPService `json:"rdp"`


### PR DESCRIPTION
- New endpoint added to host store: GET `/host-store/api/v1/settings/default_service_options`
- Added a new struct `DefaultServiceOptions` to the host store model