### PR TITLE
feat(API): add new client licensemanager to SDK and endpoints

### DIFF
--- a/api/licensemanager/client.go
+++ b/api/licensemanager/client.go
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 SSH Communications Security Inc.
+// Copyright (c) 2021 SSH Communications Security Inc.
 //
 // All rights reserved.
 //
@@ -34,8 +34,8 @@ func (store *LicenseManager) SetLicenseStatistics(optin bool) error {
 	return err
 }
 
-// CreateLicense post a new license to server
-func (store *LicenseManager) CreateLicense(license string) error {
+// SetLicense post a new license to server
+func (store *LicenseManager) SetLicense(license string) error {
 	_, err := store.api.
 		URL("/license-manager/api/v1/license").
 		Post(license)

--- a/api/licensemanager/client.go
+++ b/api/licensemanager/client.go
@@ -35,10 +35,10 @@ func (store *LicenseManager) SetLicenseStatistics(optin bool) error {
 }
 
 // SetLicense post a new license to server
-func (store *LicenseManager) SetLicense(license string) error {
+func (store *LicenseManager) SetLicense(licenseCode string) error {
 	_, err := store.api.
 		URL("/license-manager/api/v1/license").
-		Post(license)
+		Post(licenseCode)
 
 	return err
 }

--- a/api/licensemanager/client.go
+++ b/api/licensemanager/client.go
@@ -1,0 +1,54 @@
+//
+// Copyright (c) 2020 SSH Communications Security Inc.
+//
+// All rights reserved.
+//
+
+package licensemanager
+
+import (
+	"github.com/SSHcom/privx-sdk-go/restapi"
+)
+
+type LicenseManager struct {
+	api restapi.Connector
+}
+
+// New creates a new license manager client instance, using the
+// argument SDK API client.
+func New(api restapi.Connector) *LicenseManager {
+	return &LicenseManager{api: api}
+}
+
+// SetLicenseStatistics settings for SSH license statistics
+func (store *LicenseManager) SetLicenseStatistics(optin bool) error {
+	statistics := License{
+		Optin: optin,
+	}
+
+	_, err := store.api.
+		URL("/license-manager/api/v1/license/optin").
+		Post(&statistics)
+
+	return err
+}
+
+// CreateLicense post a new license to server
+func (store *LicenseManager) CreateLicense(license string) error {
+	_, err := store.api.
+		URL("/license-manager/api/v1/license").
+		Post(license)
+
+	return err
+}
+
+// License return privx license
+func (store *LicenseManager) License() (license *License, err error) {
+	license = new(License)
+
+	_, err = store.api.
+		URL("/license-manager/api/v1/license").
+		Get(license)
+
+	return
+}

--- a/api/licensemanager/client.go
+++ b/api/licensemanager/client.go
@@ -10,6 +10,7 @@ import (
 	"github.com/SSHcom/privx-sdk-go/restapi"
 )
 
+// LicenseManager is a license manager client instance.
 type LicenseManager struct {
 	api restapi.Connector
 }

--- a/api/licensemanager/model.go
+++ b/api/licensemanager/model.go
@@ -1,0 +1,31 @@
+//
+// Copyright (c) 2020 SSH Communications Security Inc.
+//
+// All rights reserved.
+//
+
+package licensemanager
+
+// License license definition
+type License struct {
+	LicenseStatus           string   `json:"license_status,omitempty"`
+	Version                 string   `json:"version,omitempty"`
+	CreationDate            string   `json:"creation_date,omitempty"`
+	ExpiryDate              string   `json:"expiry_date,omitempty"`
+	LastRefreshedDate       string   `json:"last_refreshed_date,omitempty"`
+	Customer                string   `json:"customer,omitempty"`
+	SerialNumber            string   `json:"serial_number,omitempty"`
+	Product                 string   `json:"product,omitempty"`
+	LicenseCode             string   `json:"license_code,omitempty"`
+	Status                  int      `json:"status,omitempty"`
+	Message                 int      `json:"message,omitempty"`
+	MaxHosts                int      `json:"max_hosts,omitempty"`
+	MaxAuditedHosts         int      `json:"max_audited_hosts,omitempty"`
+	MaxConcurrentSSHConns   int      `json:"max_concurrent_ssh_conns,omitempty"`
+	MaxConcurrentRDPConns   int      `json:"max_concurrent_rdp_conns,omitempty"`
+	MaxConcurrentHTTPSConns int      `json:"max_concurrent_https_conns,omitempty"`
+	AnalyticsEnabled        bool     `json:"analytics_enabled,omitempty"`
+	IsOffline               bool     `json:"isoffline,omitempty"`
+	Optin                   bool     `json:"optin,omitempty"`
+	Features                []string `json:"features,omitempty"`
+}

--- a/api/licensemanager/model.go
+++ b/api/licensemanager/model.go
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2020 SSH Communications Security Inc.
+// Copyright (c) 2021 SSH Communications Security Inc.
 //
 // All rights reserved.
 //
@@ -24,6 +24,7 @@ type License struct {
 	MaxConcurrentSSHConns   int      `json:"max_concurrent_ssh_conns,omitempty"`
 	MaxConcurrentRDPConns   int      `json:"max_concurrent_rdp_conns,omitempty"`
 	MaxConcurrentHTTPSConns int      `json:"max_concurrent_https_conns,omitempty"`
+	MaxConcurrentVNCConns   int      `json:"max_concurrent_vnc_conns,omitempty"`
 	AnalyticsEnabled        bool     `json:"analytics_enabled,omitempty"`
 	IsOffline               bool     `json:"isoffline,omitempty"`
 	Optin                   bool     `json:"optin,omitempty"`


### PR DESCRIPTION
Included a new client to the SDK: `licensemanager` 

Added new endpoints to licensemanager:

- GET `/license-manager/api/v1/license`
- POST `/license-manager/api/v1/license/optin`
- POST `/license-manager/api/v1/license`