### PR TITLE
feat(API): add new endpoints to license manager, add new rest api

### DIFF
--- a/api/licensemanager/client.go
+++ b/api/licensemanager/client.go
@@ -27,7 +27,7 @@ func (store *LicenseManager) RefreshLicense() (license *License, err error) {
 
 	_, err = store.api.
 		URL("/license-manager/api/v1/license/refresh").
-		PostWithoutBody(license)
+		Post(nil, license)
 
 	return
 }
@@ -36,7 +36,7 @@ func (store *LicenseManager) RefreshLicense() (license *License, err error) {
 func (store *LicenseManager) DeactivateLicense() error {
 	_, err := store.api.
 		URL("/license-manager/api/v1/license/deactivate").
-		PostWithoutBody()
+		Post(nil)
 
 	return err
 }

--- a/api/licensemanager/client.go
+++ b/api/licensemanager/client.go
@@ -21,6 +21,26 @@ func New(api restapi.Connector) *LicenseManager {
 	return &LicenseManager{api: api}
 }
 
+// RefreshLicense refresh the license info
+func (store *LicenseManager) RefreshLicense() (license *License, err error) {
+	license = new(License)
+
+	_, err = store.api.
+		URL("/license-manager/api/v1/license/refresh").
+		PostWithoutBody(license)
+
+	return
+}
+
+// DeactivateLicense deactivate license
+func (store *LicenseManager) DeactivateLicense() error {
+	_, err := store.api.
+		URL("/license-manager/api/v1/license/deactivate").
+		PostWithoutBody()
+
+	return err
+}
+
 // SetLicenseStatistics settings for SSH license statistics
 func (store *LicenseManager) SetLicenseStatistics(optin bool) error {
 	statistics := License{

--- a/restapi/client.go
+++ b/restapi/client.go
@@ -208,19 +208,10 @@ func (curl *tCURL) Put(eg interface{}, in ...interface{}) (http.Header, error) {
 // Post sends content to endpoint
 func (curl *tCURL) Post(eg interface{}, in ...interface{}) (http.Header, error) {
 	curl.method = http.MethodPost
-	curl.send(eg)
 
-	if len(in) > 0 {
-		return curl.recv(in[0])
+	if eg != nil {
+		curl.send(eg)
 	}
-
-	return curl.status()
-}
-
-//
-// PostWithoutBody sends content to endpoint without entity body
-func (curl *tCURL) PostWithoutBody(in ...interface{}) (http.Header, error) {
-	curl.method = http.MethodPost
 
 	if len(in) > 0 {
 		return curl.recv(in[0])

--- a/restapi/client.go
+++ b/restapi/client.go
@@ -218,6 +218,18 @@ func (curl *tCURL) Post(eg interface{}, in ...interface{}) (http.Header, error) 
 }
 
 //
+// PostWithoutBody sends content to endpoint without entity body
+func (curl *tCURL) PostWithoutBody(in ...interface{}) (http.Header, error) {
+	curl.method = http.MethodPost
+
+	if len(in) > 0 {
+		return curl.recv(in[0])
+	}
+
+	return curl.status()
+}
+
+//
 // Delete removes content behind url
 func (curl *tCURL) Delete(in ...interface{}) (http.Header, error) {
 	curl.method = http.MethodDelete

--- a/restapi/types.go
+++ b/restapi/types.go
@@ -32,6 +32,7 @@ type CURL interface {
 	Post(interface{}, ...interface{}) (http.Header, error)
 	Delete(...interface{}) (http.Header, error)
 	Fetch() ([]byte, error)
+	PostWithoutBody(...interface{}) (http.Header, error)
 }
 
 // Authorizer provides access token for REST API client

--- a/restapi/types.go
+++ b/restapi/types.go
@@ -32,7 +32,6 @@ type CURL interface {
 	Post(interface{}, ...interface{}) (http.Header, error)
 	Delete(...interface{}) (http.Header, error)
 	Fetch() ([]byte, error)
-	PostWithoutBody(...interface{}) (http.Header, error)
 }
 
 // Authorizer provides access token for REST API client


### PR DESCRIPTION
Added new endpoints:

- POST `/license-manager/api/v1/license/refresh`
- POST `/license-manager/api/v1/license/deactivate`

Added a new rest api and type to the CURL interface in order to post content without an entity body