### PR TITLE
feat(API): add settings service to sdk and new endpoints

### DIFF
--- a/api/settings/client.go
+++ b/api/settings/client.go
@@ -1,0 +1,84 @@
+//
+// Copyright (c) 2021 SSH Communications Security Inc.
+//
+// All rights reserved.
+//
+
+package settings
+
+import (
+	"encoding/json"
+	"net/url"
+
+	"github.com/SSHcom/privx-sdk-go/restapi"
+)
+
+// Settings is a settings client instance.
+type Settings struct {
+	api restapi.Connector
+}
+
+// New creates a new settings client instance, using the
+// argument SDK API client.
+func New(api restapi.Connector) *Settings {
+	return &Settings{api: api}
+}
+
+// SectionSchema get schema for the section
+func (store *Settings) SectionSchema(scope, section string) (schema json.RawMessage, err error) {
+	_, err = store.api.
+		URL("/settings/api/v1/schema/%s/%s", url.PathEscape(scope), url.PathEscape(section)).
+		Get(&schema)
+
+	return
+}
+
+// ScopeSchema get schema for the scope
+func (store *Settings) ScopeSchema(scope string) (schema json.RawMessage, err error) {
+	_, err = store.api.
+		URL("/settings/api/v1/schema/%s", url.PathEscape(scope)).
+		Get(&schema)
+
+	return
+}
+
+// UpdateScopeSectionSettings update settings for a scope and section combination
+func (store *Settings) UpdateScopeSectionSettings(settings *json.RawMessage, scope, section string) error {
+	_, err := store.api.
+		URL("/settings/api/v1/settings/%s/%s", url.PathEscape(scope), url.PathEscape(section)).
+		Put(settings)
+
+	return err
+}
+
+// ScopeSectionSettings get settings for the scope
+func (store *Settings) ScopeSectionSettings(scope, section, merge string) (settings json.RawMessage, err error) {
+	filter := Params{
+		Merge: merge,
+	}
+
+	_, err = store.api.
+		URL("/settings/api/v1/settings/%s/%s", url.PathEscape(scope), url.PathEscape(section)).
+		Query(&filter).
+		Get(&settings)
+
+	return
+}
+
+// ScopeSettings get settings for the scope
+func (store *Settings) ScopeSettings(scope string) (settings json.RawMessage, err error) {
+	_, err = store.api.
+		URL("/settings/api/v1/settings/%s", url.PathEscape(scope)).
+		Get(&settings)
+
+	return
+}
+
+// UpdateScopeSettings update settings for a scope.
+func (store *Settings) UpdateScopeSettings(settings *json.RawMessage, scope string) error {
+	_, err := store.api.
+		URL("/settings/api/v1/settings/%s", url.PathEscape(scope)).
+		Put(settings)
+
+	return err
+}

--- a/api/settings/client.go
+++ b/api/settings/client.go
@@ -25,7 +25,7 @@ func New(api restapi.Connector) *Settings {
 }
 
 // SectionSchema get schema for the section
-func (store *Settings) SectionSchema(scope, section string) (schema json.RawMessage, err error) {
+func (store *Settings) SectionSchema(scope, section string) (schema *json.RawMessage, err error) {
 	_, err = store.api.
 		URL("/settings/api/v1/schema/%s/%s", url.PathEscape(scope), url.PathEscape(section)).
 		Get(&schema)
@@ -34,7 +34,7 @@ func (store *Settings) SectionSchema(scope, section string) (schema json.RawMess
 }
 
 // ScopeSchema get schema for the scope
-func (store *Settings) ScopeSchema(scope string) (schema json.RawMessage, err error) {
+func (store *Settings) ScopeSchema(scope string) (schema *json.RawMessage, err error) {
 	_, err = store.api.
 		URL("/settings/api/v1/schema/%s", url.PathEscape(scope)).
 		Get(&schema)
@@ -52,23 +52,23 @@ func (store *Settings) UpdateScopeSectionSettings(settings *json.RawMessage, sco
 }
 
 // ScopeSectionSettings get settings for the scope
-func (store *Settings) ScopeSectionSettings(scope, section, merge string) (settings json.RawMessage, err error) {
-	filter := Params{
-		Merge: merge,
-	}
-
+func (store *Settings) ScopeSectionSettings(scope, section string) (settings *json.RawMessage, err error) {
 	_, err = store.api.
 		URL("/settings/api/v1/settings/%s/%s", url.PathEscape(scope), url.PathEscape(section)).
-		Query(&filter).
 		Get(&settings)
 
 	return
 }
 
 // ScopeSettings get settings for the scope
-func (store *Settings) ScopeSettings(scope string) (settings json.RawMessage, err error) {
+func (store *Settings) ScopeSettings(scope, merge string) (settings *json.RawMessage, err error) {
+	filter := Params{
+		Merge: merge,
+	}
+
 	_, err = store.api.
 		URL("/settings/api/v1/settings/%s", url.PathEscape(scope)).
+		Query(&filter).
 		Get(&settings)
 
 	return

--- a/api/settings/model.go
+++ b/api/settings/model.go
@@ -6,7 +6,7 @@
 
 package settings
 
-// Params struct for pagination queries.
+// Params query parameter definition
 type Params struct {
 	Merge string `json:"merge,omitempty"`
 }

--- a/api/settings/model.go
+++ b/api/settings/model.go
@@ -1,0 +1,12 @@
+//
+// Copyright (c) 2021 SSH Communications Security Inc.
+//
+// All rights reserved.
+//
+
+package settings
+
+// Params struct for pagination queries.
+type Params struct {
+	Merge string `json:"merge,omitempty"`
+}


### PR DESCRIPTION
Add settings service client and model to SDK

Add new endpoints to settings service:

- GET `/settings/api/v1/settings/{scope}`
- PUT `/settings/api/v1/settings/{scope}`
- GET `/settings/api/v1/settings/{scope}/{section}`
- PUT `/settings/api/v1/settings/{scope}/{section}`
- GET `/settings/api/v1/schema/{scope}`
- GET `/settings/api/v1/schema/{scope}/{section}`