### PR TITLE
feat(API): add monitor client to SDK and new endpoints

### DIFF
--- a/api/monitor/client.go
+++ b/api/monitor/client.go
@@ -1,0 +1,117 @@
+//
+// Copyright (c) 2021 SSH Communications Security Inc.
+//
+// All rights reserved.
+//
+
+package monitor
+
+import (
+	"encoding/json"
+	"net/url"
+
+	"github.com/SSHcom/privx-sdk-go/restapi"
+)
+
+// Monitor is a monitor service client instance.
+type Monitor struct {
+	api restapi.Connector
+}
+
+type eventsResult struct {
+	Count int          `json:"count"`
+	Items []AuditEvent `json:"items"`
+}
+
+// New creates a new monitor service client instance, using the
+// argument SDK API client.
+func New(api restapi.Connector) *Monitor {
+	return &Monitor{api: api}
+}
+
+// TerminateInstances terminate PrivX instances
+func (store *Monitor) TerminateInstances() error {
+	_, err := store.api.
+		URL("/monitor-service/api/v1/instance/exit").
+		Post(nil)
+
+	return err
+}
+
+// InstanceStatus status of the whole instance
+func (store *Monitor) InstanceStatus() (status *json.RawMessage, err error) {
+	_, err = store.api.
+		URL("/monitor-service/api/v1/instance/status").
+		Get(&status)
+
+	return
+}
+
+// AuditEventCodes get audit event codes
+func (store *Monitor) AuditEventCodes() (codes *AuditEventCodes, err error) {
+	codes = new(AuditEventCodes)
+
+	_, err = store.api.
+		URL("/monitor-service/api/v1/auditevents/codes").
+		Get(codes)
+
+	return
+}
+
+// SearchAuditEvents search for audit events
+func (store *Monitor) SearchAuditEvents(keywords, offset, limit, sortkey, sortdir string, fuzzycount bool) ([]AuditEvent, error) {
+	result := eventsResult{}
+	filters := Params{
+		Offset:     offset,
+		Limit:      limit,
+		Sortkey:    sortkey,
+		Sortdir:    sortdir,
+		FuzzyCount: fuzzycount,
+	}
+
+	_, err := store.api.
+		URL("/monitor-service/api/v1/auditevents/search").
+		Query(&filters).
+		Post(map[string]string{
+			"keywords": keywords,
+		}, &result)
+
+	return result.Items, err
+}
+
+// AuditEvents get all audit events
+func (store *Monitor) AuditEvents(offset, limit, sortkey, sortdir string, fuzzycount bool) ([]AuditEvent, error) {
+	result := eventsResult{}
+	filters := Params{
+		Offset:     offset,
+		Limit:      limit,
+		Sortdir:    sortdir,
+		Sortkey:    sortkey,
+		FuzzyCount: fuzzycount,
+	}
+
+	_, err := store.api.
+		URL("/monitor-service/api/v1/auditevents").
+		Query(&filters).
+		Get(&result)
+
+	return result.Items, err
+}
+
+// ComponentsStatus get the status of all deployed privx components
+func (store *Monitor) ComponentsStatus() (status *json.RawMessage, err error) {
+	_, err = store.api.
+		URL("/monitor-service/api/v1/components").
+		Get(&status)
+
+	return
+}
+
+// HostComponentStatus get component status object by hostname.
+func (store *Monitor) HostComponentStatus(hostname string) (status *json.RawMessage, err error) {
+	_, err = store.api.
+		URL("/monitor-service/api/v1/components/%s", url.PathEscape(hostname)).
+		Get(&status)
+
+	return
+}

--- a/api/monitor/model.go
+++ b/api/monitor/model.go
@@ -1,0 +1,44 @@
+//
+// Copyright (c) 2021 SSH Communications Security Inc.
+//
+// All rights reserved.
+//
+
+package monitor
+
+// Params struct for pagination queries.
+type Params struct {
+	Offset     string `json:"offset,omitempty"`
+	Limit      string `json:"limit,omitempty"`
+	Sortdir    string `json:"sortdir,omitempty"`
+	Sortkey    string `json:"sortkey,omitempty"`
+	FuzzyCount bool   `json:"fuzzycount,omitempty"`
+}
+
+// AuditEventCodes audit event codes definitions
+type AuditEventCodes struct {
+	EventCode  int        `json:"key,omitempty"`
+	EventValue EventValue `json:"value,omitempty"`
+}
+
+// EventValue audit event codes value definitions
+type EventValue struct {
+	EventID          string `json:"event_id,omitempty"`
+	EventName        string `json:"event_name,omitempty"`
+	EventDescription string `json:"event_desc,omitempty"`
+}
+
+// AuditEvent audit event definitions
+type AuditEvent struct {
+	ServiceID   string `json:"service_id,omitempty"`
+	ServiceName string `json:"service_name,omitempty"`
+	EventID     string `json:"event_id,omitempty"`
+	EventName   string `json:"event_name,omitempty"`
+	Created     string `json:"created,omitempty"`
+	Message     Message
+}
+
+// Message message definitions
+type Message struct {
+	Message string `json:"message,omitempty"`
+}

--- a/api/monitor/model.go
+++ b/api/monitor/model.go
@@ -16,29 +16,21 @@ type Params struct {
 }
 
 // AuditEventCodes audit event codes definitions
-type AuditEventCodes struct {
-	EventCode  int        `json:"key,omitempty"`
-	EventValue EventValue `json:"value,omitempty"`
-}
+type AuditEventCodes map[string]AuditEventInfo
 
-// EventValue audit event codes value definitions
-type EventValue struct {
-	EventID          string `json:"event_id,omitempty"`
-	EventName        string `json:"event_name,omitempty"`
-	EventDescription string `json:"event_desc,omitempty"`
+// AuditEventInfo audit event codes value definitions
+type AuditEventInfo struct {
+	EventID          int    `json:"event_id"`
+	EventName        string `json:"event_name"`
+	EventDescription string `json:"event_desc"`
 }
 
 // AuditEvent audit event definitions
 type AuditEvent struct {
-	ServiceID   string `json:"service_id,omitempty"`
-	ServiceName string `json:"service_name,omitempty"`
-	EventID     string `json:"event_id,omitempty"`
-	EventName   string `json:"event_name,omitempty"`
-	Created     string `json:"created,omitempty"`
-	Message     Message
-}
-
-// Message message definitions
-type Message struct {
-	Message string `json:"message,omitempty"`
+	ServiceID   string            `json:"service_id,omitempty"`
+	ServiceName string            `json:"service_name,omitempty"`
+	EventID     string            `json:"event_id,omitempty"`
+	EventName   string            `json:"event_name,omitempty"`
+	Created     string            `json:"created,omitempty"`
+	Message     map[string]string `json:"message,omitempty"`
 }


### PR DESCRIPTION
Added a new client, monitor, too SDK.
Added new endpoints to monitor service:

- GET `/monitor-service/api/v1/components`
- GET `/monitor-service/api/v1/components/{hostname}`
- POST `/monitor-service/api/v1/auditevents/search`
- GET `/monitor-service/api/v1/auditevents`
- GET `/monitor-service/api/v1/auditevents/codes`
- GET `/monitor-service/api/v1/instance/status`
- POST `/monitor-service/api/v1/instance/exit`