### PR TITLE
feat(API): add new client and endpoits  to SDK, trail index

### DIFF
--- a/api/trailindex/client.go
+++ b/api/trailindex/client.go
@@ -1,0 +1,79 @@
+//
+// Copyright (c) 2021 SSH Communications Security Inc.
+//
+// All rights reserved.
+//
+
+package trailindex
+
+import (
+	"net/url"
+
+	"github.com/SSHcom/privx-sdk-go/restapi"
+)
+
+// TrailIndex is a trail index client instance.
+type TrailIndex struct {
+	api restapi.Connector
+}
+
+type trailIndexResult struct {
+	Count int                  `json:"count"`
+	Items []TrailIndexResponse `json:"items"`
+}
+
+// New creates a new trail index client instance, using the
+// argument SDK API client.
+func New(api restapi.Connector) *TrailIndex {
+	return &TrailIndex{api: api}
+}
+
+// SearchContent search for the content based on the search parameters defined
+func (store *TrailIndex) SearchContent(offset, limit, sortdir string, searchObject SearchRequestObject) ([]TrailIndexResponse, error) {
+	result := trailIndexResult{}
+	filters := Params{
+		Offset:  offset,
+		Limit:   limit,
+		Sortdir: sortdir,
+	}
+
+	_, err := store.api.
+		URL("/trail-index/api/v1/index/search").
+		Query(&filters).
+		Post(&searchObject, &result)
+
+	return result.Items, err
+}
+
+// StartIndexing starts indexing of the specified connections
+func (store *TrailIndex) StartIndexing(connectionIDs []string) ([]Connection, error) {
+	var connections []Connection
+
+	_, err := store.api.
+		URL("/trail-index/api/v1/index/start").
+		Post(connectionIDs, &connections)
+
+	return connections, err
+}
+
+// ConnectionStatus gets the statuses of the specified connections
+func (store *TrailIndex) ConnectionStatus(connectionIDs []string) ([]Connection, error) {
+	var connections []Connection
+
+	_, err := store.api.
+		URL("/trail-index/api/v1/index/status").
+		Post(connectionIDs, &connections)
+
+	return connections, err
+}
+
+// IndexingStatus get indexing status of the connection
+func (store *TrailIndex) IndexingStatus(connectionID string) (status *Connection, err error) {
+	status = new(Connection)
+
+	_, err = store.api.
+		URL("/trail-index/api/v1/index/%s/status", url.PathEscape(connectionID)).
+		Get(status)
+
+	return
+}

--- a/api/trailindex/client.go
+++ b/api/trailindex/client.go
@@ -56,8 +56,8 @@ func (store *TrailIndex) StartIndexing(connectionIDs []string) ([]Connection, er
 	return connections, err
 }
 
-// ConnectionStatus gets the statuses of the specified connections
-func (store *TrailIndex) ConnectionStatus(connectionIDs []string) ([]Connection, error) {
+// IndexingStatuses gets the statuses of the specified connections
+func (store *TrailIndex) IndexingStatuses(connectionIDs []string) ([]Connection, error) {
 	var connections []Connection
 
 	_, err := store.api.

--- a/api/trailindex/client.go
+++ b/api/trailindex/client.go
@@ -18,8 +18,8 @@ type TrailIndex struct {
 }
 
 type trailIndexResult struct {
-	Count int                  `json:"count"`
-	Items []TrailIndexResponse `json:"items"`
+	Count int                `json:"count"`
+	Items []TrailIndexObject `json:"items"`
 }
 
 // New creates a new trail index client instance, using the
@@ -29,7 +29,7 @@ func New(api restapi.Connector) *TrailIndex {
 }
 
 // SearchContent search for the content based on the search parameters defined
-func (store *TrailIndex) SearchContent(offset, limit, sortdir string, searchObject SearchRequestObject) ([]TrailIndexResponse, error) {
+func (store *TrailIndex) SearchContent(offset, limit, sortdir string, searchObject SearchRequestObject) ([]TrailIndexObject, error) {
 	result := trailIndexResult{}
 	filters := Params{
 		Offset:  offset,

--- a/api/trailindex/client.go
+++ b/api/trailindex/client.go
@@ -18,8 +18,8 @@ type TrailIndex struct {
 }
 
 type trailIndexResult struct {
-	Count int                `json:"count"`
-	Items []TrailIndexObject `json:"items"`
+	Count int             `json:"count"`
+	Items []IndexResponse `json:"items"`
 }
 
 // New creates a new trail index client instance, using the
@@ -29,7 +29,7 @@ func New(api restapi.Connector) *TrailIndex {
 }
 
 // SearchContent search for the content based on the search parameters defined
-func (store *TrailIndex) SearchContent(offset, limit, sortdir string, searchObject SearchRequestObject) ([]TrailIndexObject, error) {
+func (store *TrailIndex) SearchContent(offset, limit, sortdir string, searchObject SearchRequestObject) ([]IndexResponse, error) {
 	result := trailIndexResult{}
 	filters := Params{
 		Offset:  offset,

--- a/api/trailindex/model.go
+++ b/api/trailindex/model.go
@@ -13,8 +13,8 @@ type Params struct {
 	Sortdir string `json:"sortdir,omitempty"`
 }
 
-// TrailIndexResponse trail index response definition
-type TrailIndexResponse struct {
+// TrailIndexObject trail index response definition
+type TrailIndexObject struct {
 	ConnID      string `json:"connection_id,omitempty"`
 	ChanID      string `json:"channel_id,omitempty"`
 	Protocol    string `json:"protocol,omitempty"`

--- a/api/trailindex/model.go
+++ b/api/trailindex/model.go
@@ -13,15 +13,15 @@ type Params struct {
 	Sortdir string `json:"sortdir,omitempty"`
 }
 
-// TrailIndexObject trail index response definition
-type TrailIndexObject struct {
+// IndexResponse trail index response definition
+type IndexResponse struct {
 	ConnID      string `json:"connection_id,omitempty"`
 	ChanID      string `json:"channel_id,omitempty"`
 	Protocol    string `json:"protocol,omitempty"`
 	ChannelType string `json:"type,omitempty"`
 	TimeStamp   string `json:"timestamp,omitempty"`
-	Position    int    `json:"position,omitempty"`
 	Content     string `json:"content,omitempty"`
+	Position    int    `json:"position,omitempty"`
 }
 
 // SearchRequestObject search request object definition
@@ -32,8 +32,8 @@ type SearchRequestObject struct {
 	Keywords  string `json:"keywords"`
 	StartTime string `json:"start_time"`
 	EndTime   string `json:"end_time"`
-	StartPos  *int   `json:"start_position"`
-	EndPos    *int   `json:"end_position"`
+	StartPos  int    `json:"start_position"`
+	EndPos    int    `json:"end_position"`
 }
 
 // Connection connection definition

--- a/api/trailindex/model.go
+++ b/api/trailindex/model.go
@@ -1,0 +1,43 @@
+//
+// Copyright (c) 2021 SSH Communications Security Inc.
+//
+// All rights reserved.
+//
+
+package trailindex
+
+// Params struct for pagination queries.
+type Params struct {
+	Offset  string `json:"offset,omitempty"`
+	Limit   string `json:"limit,omitempty"`
+	Sortdir string `json:"sortdir,omitempty"`
+}
+
+// TrailIndexResponse trail index response definition
+type TrailIndexResponse struct {
+	ConnID      string `json:"connection_id,omitempty"`
+	ChanID      string `json:"channel_id,omitempty"`
+	Protocol    string `json:"protocol,omitempty"`
+	ChannelType string `json:"type,omitempty"`
+	TimeStamp   string `json:"timestamp,omitempty"`
+	Position    int    `json:"position,omitempty"`
+	Content     string `json:"content,omitempty"`
+}
+
+// SearchRequestObject search request object definition
+type SearchRequestObject struct {
+	ConnID    string `json:"connection_id"`
+	ChanID    string `json:"channel_id"`
+	Protocol  string `json:"protocol"`
+	Keywords  string `json:"keywords"`
+	StartTime string `json:"start_time"`
+	EndTime   string `json:"end_time"`
+	StartPos  *int   `json:"start_position"`
+	EndPos    *int   `json:"end_position"`
+}
+
+// Connection connection definition
+type Connection struct {
+	ConnID string `json:"connection_id,omitempty"`
+	Status string `json:"status,omitempty"`
+}


### PR DESCRIPTION
Added new client and model to SDK, trail-index.

Added new endpoints to trail-index service.

- GET `/trail-index/api/v1/index/{connection_id}/status`
- POST `/trail-index/api/v1/index/status`
- POST `/trail-index/api/v1/index/start`
- POST `/trail-index/api/v1/index/search`