### PR TITLE
feat(API): add new client, workflow engine, and endpoints to sdk

### DIFF
--- a/api/workflow/client.go
+++ b/api/workflow/client.go
@@ -58,7 +58,7 @@ func (store *Engine) Workflow(workflowID string) (workflow *Workflow, err error)
 }
 
 // CreateWorkflow create a new workflow
-func (store *Engine) CreateWorkflow(workflow Workflow) (string, error) {
+func (store *Engine) CreateWorkflow(workflow *Workflow) (string, error) {
 	var id struct {
 		ID string `json:"id"`
 	}

--- a/api/workflow/client.go
+++ b/api/workflow/client.go
@@ -65,7 +65,7 @@ func (store *Engine) CreateWorkflow(workflow Workflow) (string, error) {
 
 	_, err := store.api.
 		URL("/workflow-engine/api/v1/workflows").
-		Post(workflow, &id)
+		Post(&workflow, &id)
 
 	return id.ID, err
 }

--- a/api/workflow/client.go
+++ b/api/workflow/client.go
@@ -1,0 +1,87 @@
+//
+// Copyright (c) 2021 SSH Communications Security Inc.
+//
+// All rights reserved.
+//
+
+package workflow
+
+import (
+	"net/url"
+
+	"github.com/SSHcom/privx-sdk-go/restapi"
+)
+
+// Workflow is a workflow client instance.
+type WorkflowEngine struct {
+	api restapi.Connector
+}
+
+type workflowsResult struct {
+	Count int        `json:"count"`
+	Items []Workflow `json:"items"`
+}
+
+// New creates a new workflow client instance, using the
+// argument SDK API client.
+func New(api restapi.Connector) *WorkflowEngine {
+	return &WorkflowEngine{api: api}
+}
+
+// UpdateWorkflow update  a workflow
+func (store *WorkflowEngine) UpdateWorkflow(workflowID string, workflow *Workflow) error {
+	_, err := store.api.
+		URL("/workflow-engine/api/v1/workflows/%s", url.PathEscape(workflowID)).
+		Put(workflow)
+
+	return err
+}
+
+// DeleteWorkflow delete a workflow by ID
+func (store *WorkflowEngine) DeleteWorkflow(workflowID string) error {
+	_, err := store.api.
+		URL("/workflow-engine/api/v1/workflows/%s", workflowID).
+		Delete()
+
+	return err
+}
+
+// Workflow return workflow object by ID
+func (store *WorkflowEngine) Workflow(workflowID string) (workflow *Workflow, err error) {
+	workflow = new(Workflow)
+
+	_, err = store.api.
+		URL("/workflow-engine/api/v1/workflows/%s", url.PathEscape(workflowID)).
+		Get(workflow)
+
+	return workflow, err
+}
+
+// CreateWorkflow create a new workflow
+func (store *WorkflowEngine) CreateWorkflow(workflow Workflow) (string, error) {
+	var id struct {
+		ID string `json:"id"`
+	}
+
+	_, err := store.api.
+		URL("/workflow-engine/api/v1/workflows").
+		Post(workflow, &id)
+
+	return id.ID, err
+}
+
+// Workflows get all workflows
+func (store *WorkflowEngine) Workflows(offset, limit string) ([]Workflow, error) {
+	result := workflowsResult{}
+	filters := Params{
+		Offset: offset,
+		Limit:  limit,
+	}
+
+	_, err := store.api.
+		URL("/workflow-engine/api/v1/workflows").
+		Query(&filters).
+		Get(&result)
+
+	return result.Items, err
+}

--- a/api/workflow/client.go
+++ b/api/workflow/client.go
@@ -12,24 +12,24 @@ import (
 	"github.com/SSHcom/privx-sdk-go/restapi"
 )
 
-// Workflow is a workflow client instance.
-type Workflow struct {
+// Engine is a workflow client instance.
+type Engine struct {
 	api restapi.Connector
 }
 
 type workflowsResult struct {
-	Count int                `json:"count"`
-	Items []WorkflowResponse `json:"items"`
+	Count int        `json:"count"`
+	Items []Workflow `json:"items"`
 }
 
 // New creates a new workflow client instance, using the
 // argument SDK API client.
-func New(api restapi.Connector) *Workflow {
-	return &Workflow{api: api}
+func New(api restapi.Connector) *Engine {
+	return &Engine{api: api}
 }
 
 // UpdateWorkflow update  a workflow
-func (store *Workflow) UpdateWorkflow(workflowID string, workflow *WorkflowResponse) error {
+func (store *Engine) UpdateWorkflow(workflowID string, workflow *Workflow) error {
 	_, err := store.api.
 		URL("/workflow-engine/api/v1/workflows/%s", url.PathEscape(workflowID)).
 		Put(workflow)
@@ -38,7 +38,7 @@ func (store *Workflow) UpdateWorkflow(workflowID string, workflow *WorkflowRespo
 }
 
 // DeleteWorkflow delete a workflow by ID
-func (store *Workflow) DeleteWorkflow(workflowID string) error {
+func (store *Engine) DeleteWorkflow(workflowID string) error {
 	_, err := store.api.
 		URL("/workflow-engine/api/v1/workflows/%s", workflowID).
 		Delete()
@@ -47,8 +47,8 @@ func (store *Workflow) DeleteWorkflow(workflowID string) error {
 }
 
 // Workflow return workflow object by ID
-func (store *Workflow) Workflow(workflowID string) (workflow *WorkflowResponse, err error) {
-	workflow = new(WorkflowResponse)
+func (store *Engine) Workflow(workflowID string) (workflow *Workflow, err error) {
+	workflow = new(Workflow)
 
 	_, err = store.api.
 		URL("/workflow-engine/api/v1/workflows/%s", url.PathEscape(workflowID)).
@@ -58,7 +58,7 @@ func (store *Workflow) Workflow(workflowID string) (workflow *WorkflowResponse, 
 }
 
 // CreateWorkflow create a new workflow
-func (store *Workflow) CreateWorkflow(workflow WorkflowResponse) (string, error) {
+func (store *Engine) CreateWorkflow(workflow Workflow) (string, error) {
 	var id struct {
 		ID string `json:"id"`
 	}
@@ -71,7 +71,7 @@ func (store *Workflow) CreateWorkflow(workflow WorkflowResponse) (string, error)
 }
 
 // Workflows get all workflows
-func (store *Workflow) Workflows(offset, limit string) ([]WorkflowResponse, error) {
+func (store *Engine) Workflows(offset, limit string) ([]Workflow, error) {
 	result := workflowsResult{}
 	filters := Params{
 		Offset: offset,

--- a/api/workflow/client.go
+++ b/api/workflow/client.go
@@ -12,24 +12,24 @@ import (
 	"github.com/SSHcom/privx-sdk-go/restapi"
 )
 
-// WorkflowEngine is a workflow client instance.
-type WorkflowEngine struct {
+// Workflow is a workflow client instance.
+type Workflow struct {
 	api restapi.Connector
 }
 
 type workflowsResult struct {
-	Count int        `json:"count"`
-	Items []Workflow `json:"items"`
+	Count int                `json:"count"`
+	Items []WorkflowResponse `json:"items"`
 }
 
 // New creates a new workflow client instance, using the
 // argument SDK API client.
-func New(api restapi.Connector) *WorkflowEngine {
-	return &WorkflowEngine{api: api}
+func New(api restapi.Connector) *Workflow {
+	return &Workflow{api: api}
 }
 
 // UpdateWorkflow update  a workflow
-func (store *WorkflowEngine) UpdateWorkflow(workflowID string, workflow *Workflow) error {
+func (store *Workflow) UpdateWorkflow(workflowID string, workflow *WorkflowResponse) error {
 	_, err := store.api.
 		URL("/workflow-engine/api/v1/workflows/%s", url.PathEscape(workflowID)).
 		Put(workflow)
@@ -38,7 +38,7 @@ func (store *WorkflowEngine) UpdateWorkflow(workflowID string, workflow *Workflo
 }
 
 // DeleteWorkflow delete a workflow by ID
-func (store *WorkflowEngine) DeleteWorkflow(workflowID string) error {
+func (store *Workflow) DeleteWorkflow(workflowID string) error {
 	_, err := store.api.
 		URL("/workflow-engine/api/v1/workflows/%s", workflowID).
 		Delete()
@@ -47,8 +47,8 @@ func (store *WorkflowEngine) DeleteWorkflow(workflowID string) error {
 }
 
 // Workflow return workflow object by ID
-func (store *WorkflowEngine) Workflow(workflowID string) (workflow *Workflow, err error) {
-	workflow = new(Workflow)
+func (store *Workflow) Workflow(workflowID string) (workflow *WorkflowResponse, err error) {
+	workflow = new(WorkflowResponse)
 
 	_, err = store.api.
 		URL("/workflow-engine/api/v1/workflows/%s", url.PathEscape(workflowID)).
@@ -58,7 +58,7 @@ func (store *WorkflowEngine) Workflow(workflowID string) (workflow *Workflow, er
 }
 
 // CreateWorkflow create a new workflow
-func (store *WorkflowEngine) CreateWorkflow(workflow Workflow) (string, error) {
+func (store *Workflow) CreateWorkflow(workflow WorkflowResponse) (string, error) {
 	var id struct {
 		ID string `json:"id"`
 	}
@@ -71,7 +71,7 @@ func (store *WorkflowEngine) CreateWorkflow(workflow Workflow) (string, error) {
 }
 
 // Workflows get all workflows
-func (store *WorkflowEngine) Workflows(offset, limit string) ([]Workflow, error) {
+func (store *Workflow) Workflows(offset, limit string) ([]WorkflowResponse, error) {
 	result := workflowsResult{}
 	filters := Params{
 		Offset: offset,

--- a/api/workflow/client.go
+++ b/api/workflow/client.go
@@ -12,7 +12,7 @@ import (
 	"github.com/SSHcom/privx-sdk-go/restapi"
 )
 
-// Workflow is a workflow client instance.
+// WorkflowEngine is a workflow client instance.
 type WorkflowEngine struct {
 	api restapi.Connector
 }

--- a/api/workflow/model.go
+++ b/api/workflow/model.go
@@ -1,0 +1,67 @@
+//
+// Copyright (c) 2021 SSH Communications Security Inc.
+//
+// All rights reserved.
+//
+
+package workflow
+
+// Params struct for pagination queries
+type Params struct {
+	Offset  string `json:"offset,omitempty"`
+	Limit   string `json:"limit,omitempty"`
+	Sortkey string `json:"sortkey,omitempty"`
+	Sortdir string `json:"sortdir,omitempty"`
+	Filter  string `json:"filter,omitempty"`
+}
+
+// WorkflowStepApprover workflow step approver defintion
+type WorkflowStepApprover struct {
+	ID   string       `json:"id,omitempty"`
+	Role WorkflowRole `json:"role,omitempty"`
+}
+
+// WorkflowStep workflow step definition
+type WorkflowStep struct {
+	ID        string                 `json:"id,omitempty"`
+	Name      string                 `json:"name,omitempty"`
+	Match     string                 `json:"match,omitempty"`
+	Approvers []WorkflowStepApprover `json:"approvers,omitempty"`
+}
+
+// WorkflowRole workflow frole definition
+type WorkflowRole struct {
+	ID      string `json:"id,omitempty"`
+	Name    string `json:"name,omitempty"`
+	Deleted bool   `json:"deleted,omitempty"`
+}
+
+// WorkflowUser workflow user definition
+type WorkflowUser struct {
+	ID          string `json:"id,omitempty"`
+	DisplayName string `json:"display_name,omitempty"`
+}
+
+// Workflow workflow response definition
+type Workflow struct {
+	ID                   string         `json:"id,omitempty"`
+	Author               string         `json:"author,omitempty"`
+	Created              string         `json:"created,omitempty"`
+	Updated              string         `json:"updated,omitempty"`
+	UpdatedBy            string         `json:"updated_by,omitempty"`
+	Name                 string         `json:"name,omitempty"`
+	RequestJustification string         `json:"request_justification,omitempty"`
+	GrantType            string         `json:"grant_type,omitempty"`
+	GrantStart           string         `json:"grant_start,omitempty"`
+	GrantEnd             string         `json:"grant_end,omitempty"`
+	Action               string         `json:"action,omitempty"`
+	Status               string         `json:"status,omitempty"`
+	Comment              string         `json:"comment,omitempty"`
+	WorkflowID           string         `json:"workflow,omitempty"`
+	FloatingLength       int            `json:"floating_length,omitempty"`
+	TargetRoles          []WorkflowRole `json:"target_roles,omitempty"`
+	Steps                []WorkflowStep `json:"steps,omitempty"`
+	TargetUser           WorkflowUser   `json:"target_user,omitempty"`
+	Requester            WorkflowUser   `json:"requester,omitempty"`
+	RequestedRole        WorkflowRole   `json:"requested_role,omitempty"`
+}

--- a/api/workflow/model.go
+++ b/api/workflow/model.go
@@ -42,8 +42,8 @@ type User struct {
 	DisplayName string `json:"display_name,omitempty"`
 }
 
-// Workflow workflow response definition
-type Workflow struct {
+// WorkflowResponse workflow response definition
+type WorkflowResponse struct {
 	ID                   string `json:"id,omitempty"`
 	Author               string `json:"author,omitempty"`
 	Created              string `json:"created,omitempty"`

--- a/api/workflow/model.go
+++ b/api/workflow/model.go
@@ -15,53 +15,53 @@ type Params struct {
 	Filter  string `json:"filter,omitempty"`
 }
 
-// WorkflowStepApprover workflow step approver defintion
-type WorkflowStepApprover struct {
-	ID   string       `json:"id,omitempty"`
-	Role WorkflowRole `json:"role,omitempty"`
+// StepApprover workflow step approver defintion
+type StepApprover struct {
+	ID   string `json:"id,omitempty"`
+	Role Role   `json:"role,omitempty"`
 }
 
-// WorkflowStep workflow step definition
-type WorkflowStep struct {
-	ID        string                 `json:"id,omitempty"`
-	Name      string                 `json:"name,omitempty"`
-	Match     string                 `json:"match,omitempty"`
-	Approvers []WorkflowStepApprover `json:"approvers,omitempty"`
+// Step workflow step definition
+type Step struct {
+	ID        string         `json:"id,omitempty"`
+	Name      string         `json:"name,omitempty"`
+	Match     string         `json:"match,omitempty"`
+	Approvers []StepApprover `json:"approvers,omitempty"`
 }
 
-// WorkflowRole workflow frole definition
-type WorkflowRole struct {
+// Role workflow frole definition
+type Role struct {
 	ID      string `json:"id,omitempty"`
 	Name    string `json:"name,omitempty"`
 	Deleted bool   `json:"deleted,omitempty"`
 }
 
-// WorkflowUser workflow user definition
-type WorkflowUser struct {
+// User workflow user definition
+type User struct {
 	ID          string `json:"id,omitempty"`
 	DisplayName string `json:"display_name,omitempty"`
 }
 
 // Workflow workflow response definition
 type Workflow struct {
-	ID                   string         `json:"id,omitempty"`
-	Author               string         `json:"author,omitempty"`
-	Created              string         `json:"created,omitempty"`
-	Updated              string         `json:"updated,omitempty"`
-	UpdatedBy            string         `json:"updated_by,omitempty"`
-	Name                 string         `json:"name,omitempty"`
-	RequestJustification string         `json:"request_justification,omitempty"`
-	GrantType            string         `json:"grant_type,omitempty"`
-	GrantStart           string         `json:"grant_start,omitempty"`
-	GrantEnd             string         `json:"grant_end,omitempty"`
-	Action               string         `json:"action,omitempty"`
-	Status               string         `json:"status,omitempty"`
-	Comment              string         `json:"comment,omitempty"`
-	WorkflowID           string         `json:"workflow,omitempty"`
-	FloatingLength       int            `json:"floating_length,omitempty"`
-	TargetRoles          []WorkflowRole `json:"target_roles,omitempty"`
-	Steps                []WorkflowStep `json:"steps,omitempty"`
-	TargetUser           WorkflowUser   `json:"target_user,omitempty"`
-	Requester            WorkflowUser   `json:"requester,omitempty"`
-	RequestedRole        WorkflowRole   `json:"requested_role,omitempty"`
+	ID                   string `json:"id,omitempty"`
+	Author               string `json:"author,omitempty"`
+	Created              string `json:"created,omitempty"`
+	Updated              string `json:"updated,omitempty"`
+	UpdatedBy            string `json:"updated_by,omitempty"`
+	Name                 string `json:"name,omitempty"`
+	RequestJustification string `json:"request_justification,omitempty"`
+	GrantType            string `json:"grant_type,omitempty"`
+	GrantStart           string `json:"grant_start,omitempty"`
+	GrantEnd             string `json:"grant_end,omitempty"`
+	Action               string `json:"action,omitempty"`
+	Status               string `json:"status,omitempty"`
+	Comment              string `json:"comment,omitempty"`
+	WorkflowID           string `json:"workflow,omitempty"`
+	FloatingLength       int    `json:"floating_length,omitempty"`
+	TargetRoles          []Role `json:"target_roles,omitempty"`
+	Steps                []Step `json:"steps,omitempty"`
+	TargetUser           User   `json:"target_user,omitempty"`
+	Requester            User   `json:"requester,omitempty"`
+	RequestedRole        Role   `json:"requested_role,omitempty"`
 }

--- a/api/workflow/model.go
+++ b/api/workflow/model.go
@@ -42,8 +42,8 @@ type User struct {
 	DisplayName string `json:"display_name,omitempty"`
 }
 
-// WorkflowResponse workflow response definition
-type WorkflowResponse struct {
+// Workflow workflow response definition
+type Workflow struct {
 	ID                   string `json:"id,omitempty"`
 	Author               string `json:"author,omitempty"`
 	Created              string `json:"created,omitempty"`


### PR DESCRIPTION
Added a new client and model, workflow-engine to the SDK.

New added endpoints:

- GET `/workflow-engine/api/v1/workflows`
- POST `/workflow-engine/api/v1/workflows`
- GET `/workflow-engine/api/v1/workflows/{workflow_id}`
- DELETE `workflow-engine/api/v1/workflows/{workflow_id}`
- PUT `workflow-engine/api/v1/workflows/{workflow_id}`