### PR TITLE
feat(API): add new client to sdk, add new restapi and type

### DIFF
--- a/api/connectionmanager/client.go
+++ b/api/connectionmanager/client.go
@@ -1,0 +1,99 @@
+//
+// Copyright (c) 2021 SSH Communications Security Inc.
+//
+// All rights reserved.
+//
+
+package connectionmanager
+
+import (
+	"net/url"
+
+	"github.com/SSHcom/privx-sdk-go/restapi"
+)
+
+// ConnectionManager is a connection manager client instance.
+type ConnectionManager struct {
+	api restapi.Connector
+}
+
+type connectionsResult struct {
+	Count int          `json:"count"`
+	Items []Connection `json:"items"`
+}
+
+// New creates a new connection manager client instance, using the
+// argument SDK API client.
+func New(api restapi.Connector) *ConnectionManager {
+	return &ConnectionManager{api: api}
+}
+
+// DownloadStoredFile download trail stored file transferred within audited connection channel
+func (store *ConnectionManager) DownloadStoredFile(connID, chanID, fileID, sessionID, filename string) error {
+	err := store.api.
+		URL("/connection-manager/api/v1/connections/%s/channel/%s/file/%s/%s",
+			url.PathEscape(connID), url.PathEscape(chanID), url.PathEscape(fileID), url.PathEscape(sessionID)).
+		Download(filename)
+
+	return err
+}
+
+// CreateSessionIDFileDownload create session ID for trail stored file download
+func (store *ConnectionManager) CreateSessionIDFileDownload(connID, chanID, fileID string) (string, error) {
+	var id struct {
+		SessionID string `json:"session_id"`
+	}
+
+	_, err := store.api.
+		URL("/connection-manager/api/v1/connections/%s/channel/%s/file/%s",
+			url.PathEscape(connID), url.PathEscape(chanID), url.PathEscape(fileID)).
+		Post(nil, &id)
+
+	return id.SessionID, err
+}
+
+// Connection get a single connection
+func (store *ConnectionManager) Connection(connID string) (*Connection, error) {
+	conn := &Connection{}
+
+	_, err := store.api.
+		URL("/connection-manager/api/v1/connections/%s", url.PathEscape(connID)).
+		Get(conn)
+
+	return conn, err
+}
+
+// SearchConnection search for connections
+func (store *ConnectionManager) SearchConnection(offset, limit, sortdir, sortkey string, searchObject ConnectionSearch) ([]Connection, error) {
+	result := connectionsResult{}
+	filters := Params{
+		Offset:  offset,
+		Limit:   limit,
+		Sortdir: sortdir,
+	}
+
+	_, err := store.api.
+		URL("/connection-manager/api/v1/connections/search").
+		Query(&filters).
+		Post(&searchObject, &result)
+
+	return result.Items, err
+}
+
+// Connections get all connections
+func (store *ConnectionManager) Connections(offset, limit, sortkey, sortdir string) ([]Connection, error) {
+	result := connectionsResult{}
+	filters := Params{
+		Offset:  offset,
+		Limit:   limit,
+		Sortkey: sortkey,
+		Sortdir: sortdir,
+	}
+
+	_, err := store.api.
+		URL("/connection-manager/api/v1/connections").
+		Query(&filters).
+		Get(&result)
+
+	return result.Items, err
+}

--- a/api/connectionmanager/client.go
+++ b/api/connectionmanager/client.go
@@ -7,7 +7,6 @@
 package connectionmanager
 
 import (
-	"fmt"
 	"net/url"
 
 	"github.com/SSHcom/privx-sdk-go/restapi"
@@ -38,7 +37,7 @@ func (store *ConnectionManager) Connections(offset, limit int, sortkey, sortdir 
 		Sortkey: sortkey,
 		Sortdir: sortdir,
 	}
-	fmt.Println(filters)
+
 	_, err := store.api.
 		URL("/connection-manager/api/v1/connections").
 		Query(&filters).

--- a/api/connectionmanager/model.go
+++ b/api/connectionmanager/model.go
@@ -8,8 +8,8 @@ package connectionmanager
 
 // Params query paramas definition
 type Params struct {
-	Offset  string `json:"offset,omitempty"`
-	Limit   string `json:"limit,omitempty"`
+	Offset  int    `json:"offset,omitempty"`
+	Limit   int    `json:"limit,omitempty"`
 	Sortdir string `json:"sortdir,omitempty"`
 	Sortkey string `json:"sortkey,omitempty"`
 	Format  string `json:"format,omitempty"`

--- a/api/connectionmanager/model.go
+++ b/api/connectionmanager/model.go
@@ -1,0 +1,109 @@
+//
+// Copyright (c) 2021 SSH Communications Security Inc.
+//
+// All rights reserved.
+//
+
+package connectionmanager
+
+// Params query paramas definition
+type Params struct {
+	Offset  string `json:"offset,omitempty"`
+	Limit   string `json:"limit,omitempty"`
+	Sortdir string `json:"sortdir,omitempty"`
+	Sortkey string `json:"sortkey,omitempty"`
+	Format  string `json:"format,omitempty"`
+	Filter  string `json:"filter,omitempty"`
+}
+
+// ConnectionHost connection host struct definition
+type ConnectionHost struct {
+	ID         string `json:"id,omitempty"`
+	CommonName string `json:"common_name,omitempty"`
+}
+
+// ConnectionRole connection role struct definition
+type ConnectionRole struct {
+	ID   string `json:"id,omitempty"`
+	Name string `json:"name,omitempty"`
+}
+
+// UserData user data struct definition
+type UserData struct {
+	ID       string `json:"id,omitempty"`
+	Username string `json:"display_name,omitempty"`
+}
+
+// AccessRoles access roles struct definition
+type AccessRoles struct {
+	ID    string `json:"id"`
+	Name  string `json:"name"`
+	Added string `json:"added"`
+}
+
+// Connection connection struct definition
+type Connection struct {
+	ID                string           `json:"id,omitempty"`
+	ProxyID           string           `json:"proxy_id,omitempty"`
+	Type              string           `json:"type,omitempty"`
+	UserAgent         string           `json:"user_agent,omitempty"`
+	TargetHostAddress string           `json:"target_host_address,omitempty"`
+	TargetHostAccount string           `json:"target_host_account,omitempty"`
+	RemoteAddress     string           `json:"remote_address,omitempty"`
+	Connected         string           `json:"connected,omitempty"`
+	Disconnected      string           `json:"disconnected,omitempty"`
+	Status            string           `json:"status,omitempty"`
+	LastActivity      string           `json:"last_activity,omitempty"`
+	ForceDisconnect   string           `json:"force_disconnect,omitempty"`
+	TerminationReason string           `json:"termination_reason,omitempty"`
+	Created           string           `json:"created,omitempty"`
+	Updated           string           `json:"updated,omitempty"`
+	UpdatedBy         string           `json:"updated_by,omitempty"`
+	TrailID           string           `json:"trail_id,omitempty"`
+	IndexStatus       string           `json:"index_status,omitempty"`
+	AccessGroupID     string           `json:"access_group_id,omitempty"`
+	AuthMethod        []string         `json:"authentication_method,omitempty"`
+	BytesIn           int              `json:"bytes_in,omitempty"`
+	BytesOut          int              `json:"bytes_out,omitempty"`
+	Duration          int              `json:"duration,omitempty"`
+	TrailRemoved      bool             `json:"trail_removed,omitempty"`
+	AuditEnabled      bool             `json:"audit_enabled,omitempty"`
+	TargetHostData    ConnectionHost   `json:"target_host_data,omitempty"`
+	UserData          UserData         `json:"user,omitempty"`
+	UserRoles         []ConnectionRole `json:"user_roles,omitempty"`
+	TargetHostRoles   []ConnectionRole `json:"target_host_roles,omitempty"`
+	AccessRoles       []AccessRoles    `json:"access_roles,omitempty"`
+}
+
+// TimestampSearch timestamp search struct definition
+type TimestampSearch struct {
+	Start string
+	End   string
+}
+
+// ConnectionSearch connection search struct definition
+type ConnectionSearch struct {
+	ID                   []string        `json:"id,omitempty"`
+	ProxyID              []string        `json:"proxy_id,omitempty"`
+	Type                 []string        `json:"type,omitempty"`
+	Mode                 []string        `json:"mode,omitempty"`
+	UserAgent            []string        `json:"user_agent,omitempty"`
+	AuthMethod           []string        `json:"authentication_method,omitempty"`
+	UserID               []string        `json:"user_id,omitempty"`
+	UserDisplayName      []string        `json:"user_display_name,omitempty"`
+	UserRoles            []string        `json:"user_roles,omitempty"`
+	TargetHost           []string        `json:"target_host_id,omitempty"`
+	TargetHostCommonName []string        `json:"target_host_common_name,omitempty"`
+	TargetHostAddress    []string        `json:"target_host_address,omitempty"`
+	TargetHostAccount    []string        `json:"target_host_account,omitempty"`
+	TargetHostRoles      []string        `json:"target_host_roles,omitempty"`
+	RemoteAddress        []string        `json:"remote_address,omitempty"`
+	Status               []string        `json:"status,omitempty"`
+	ForceDisconnect      []string        `json:"force_disconnect,omitempty"`
+	AccessRoles          []string        `json:"access_roles,omitempty"`
+	KeyWords             string          `json:"keywords,omitempty"`
+	HasAccessRoles       bool            `json:"has_access_roles,omitempty"`
+	Connected            TimestampSearch `json:"connected,omitempty"`
+	Disconnected         TimestampSearch `json:"disconnected,omitempty"`
+	LastActivity         TimestampSearch `json:"last_activity,omitempty"`
+}

--- a/go.mod
+++ b/go.mod
@@ -5,4 +5,5 @@ go 1.14
 require (
 	9fans.net/go v0.0.2 // indirect
 	github.com/BurntSushi/toml v0.3.1
+	github.com/dustin/go-humanize v1.0.0
 )

--- a/go.sum
+++ b/go.sum
@@ -2,3 +2,5 @@
 9fans.net/go v0.0.2/go.mod h1:lfPdxjq9v8pVQXUMBCx5EO5oLXWQFlKRQgs1kEkjoIM=
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
+github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=

--- a/restapi/client.go
+++ b/restapi/client.go
@@ -17,6 +17,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -139,13 +140,24 @@ func (curl *tCURL) encodeURL(query interface{}) (url.Values, error) {
 		return nil, err
 	}
 
-	var params map[string]string
+	var params map[string]interface{}
 	if err = json.Unmarshal(bin, &params); err != nil {
 		return nil, err
 	}
 
 	var values url.Values = make(map[string][]string)
-	for key, val := range params {
+	for key, param := range params {
+		var val string
+		switch v := param.(type) {
+		case int:
+			val = strconv.Itoa(v)
+		case float64:
+			val = fmt.Sprintf("%g", v)
+		case string:
+			val = v
+		default:
+			return nil, fmt.Errorf("wrong format: %T", v)
+		}
 		values[key] = []string{val}
 	}
 

--- a/restapi/types.go
+++ b/restapi/types.go
@@ -32,6 +32,7 @@ type CURL interface {
 	Post(interface{}, ...interface{}) (http.Header, error)
 	Delete(...interface{}) (http.Header, error)
 	Fetch() ([]byte, error)
+	Download(string) error
 }
 
 // Authorizer provides access token for REST API client


### PR DESCRIPTION
New client and model, connection-manager, added to the SDK.
Created a new type `Download` for the SDK in order to download a file via endpoint and save it to OS. 

New endpoints added to connection-manager:

- GET `/connection-manager/api/v1/connections`
- POST `/connection-manager/api/v1/connections/search`
- GET `/connection-manager/api/v1/connections/{connection_id}`
- POST `/connection-manager/api/v1/connections/{connection_id}/channel/{channel_id}/file/{file_id}`
- GET `/connection-manager/api/v1/connections/{connection_id}/channel/{channel_id}/file/{file_id}/{session_id}`