### PR TITLE
feat(API): add endpoints to connection manager

### DIFF
--- a/api/connectionmanager/client.go
+++ b/api/connectionmanager/client.go
@@ -97,3 +97,101 @@ func (store *ConnectionManager) DownloadStoredFile(connID, chanID, fileID, sessi
 
 	return err
 }
+
+// CreateSessionIDTrailLog create session ID for trail log download
+func (store *ConnectionManager) CreateSessionIDTrailLog(connID, chanID string) (string, error) {
+	var object struct {
+		SessionID string `json:"session_id"`
+	}
+
+	_, err := store.api.
+		URL("/connection-manager/api/v1/connections/%s/channel/%s/log",
+			url.PathEscape(connID), url.PathEscape(chanID)).
+		Post(nil, &object)
+
+	return object.SessionID, err
+}
+
+// DownloadTrailLog download trail log of audited connection channel
+func (store *ConnectionManager) DownloadTrailLog(connID, chanID, sessionID, format, filter, filename string) error {
+	filters := Params{
+		Format: format,
+		Filter: filter,
+	}
+
+	err := store.api.
+		URL("/connection-manager/api/v1/connections/%s/channel/%s/log/%s",
+			url.PathEscape(connID), url.PathEscape(chanID), url.PathEscape(sessionID)).
+		Query(&filters).
+		Download(filename)
+
+	return err
+}
+
+// SavedAccessRoles get saved access roles for a connection
+func (store *ConnectionManager) SavedAccessRoles(connID string) ([]AccessRoles, error) {
+	var result []AccessRoles
+
+	_, err := store.api.
+		URL("/connection-manager/api/v1/connections/%s/access_roles", url.PathEscape(connID)).
+		Get(&result)
+
+	return result, err
+}
+
+// GrantRolePermission grant a role permission for a connection
+func (store *ConnectionManager) GrantRolePermission(connID, roleID string) error {
+	_, err := store.api.
+		URL("/connection-manager/api/v1/connections/%s/access_roles/%s",
+			url.PathEscape(connID), url.PathEscape(roleID)).
+		Post(nil)
+
+	return err
+}
+
+// RevokeRolePermission revoke a permission for a role from a connection
+func (store *ConnectionManager) RevokeRolePermission(connID, roleID string) error {
+	_, err := store.api.
+		URL("/connection-manager/api/v1/connections/%s/access_roles/%s",
+			url.PathEscape(connID), url.PathEscape(roleID)).
+		Delete()
+
+	return err
+}
+
+// RevokeRoleFromConnection revoke permissions for a role from connections
+func (store *ConnectionManager) RevokeRoleFromConnection(roleID string) error {
+	_, err := store.api.
+		URL("/connection-manager/api/v1/connections/access_roles/%s",
+			url.PathEscape(roleID)).
+		Delete()
+
+	return err
+}
+
+// TerminateConnection terminate connection by ID.
+func (store *ConnectionManager) TerminateConnection(connID string) error {
+	_, err := store.api.
+		URL("/connection-manager/api/v1/terminate/connection/%s", url.PathEscape(connID)).
+		Post(nil)
+
+	return err
+}
+
+// TerminateConnectionFromHost terminate connection(s) from host
+func (store *ConnectionManager) TerminateConnectionFromHost(hostID string) error {
+	_, err := store.api.
+		URL("/connection-manager/api/v1/terminate/host/%s", url.PathEscape(hostID)).
+		Post(nil)
+
+	return err
+}
+
+// TerminateConnectionFromUser terminate connection(s) of a user
+func (store *ConnectionManager) TerminateConnectionFromUser(userID string) error {
+	_, err := store.api.
+		URL("/connection-manager/api/v1/terminate/user/%s", url.PathEscape(userID)).
+		Post(nil)
+
+	return err
+}


### PR DESCRIPTION
Add new endpoints to connection manager:

- POST `/connection-manager/api/v1/connections/{connection_id}/channel/{channel_id}/log`
- GET `/connection-manager/api/v1/connections/{connection_id}/channel/{channel_id}/log/{session_id}`
- GET `/connection-manager/api/v1/connections/{connection_id}/access_roles`
- POST `/connection-manager/api/v1/connections/{connection_id}/access_roles/{role_id}`
- DELETE `/connection-manager/api/v1/connections/{connection_id}/access_roles/{role_id}`
- DELETE `/connection-manager/api/v1/connections/access_roles/{role_id}`
- POST `/connection-manager/api/v1/terminate/connection/{connection_id}`
- POST `/connection-manager/api/v1/terminate/host/{host_id}`
- POST `/connection-manager/api/v1/terminate/user/{user_id}`