### PR TITLE
fix(API): restruct functions, remove named return values, naked returns

### DIFF
--- a/api/settings/client.go
+++ b/api/settings/client.go
@@ -24,22 +24,38 @@ func New(api restapi.Connector) *Settings {
 	return &Settings{api: api}
 }
 
-// SectionSchema get schema for the section
-func (store *Settings) SectionSchema(scope, section string) (schema *json.RawMessage, err error) {
-	_, err = store.api.
-		URL("/settings/api/v1/schema/%s/%s", url.PathEscape(scope), url.PathEscape(section)).
-		Get(&schema)
+// ScopeSettings get settings for the scope
+func (store *Settings) ScopeSettings(scope, merge string) (*json.RawMessage, error) {
+	settings := &json.RawMessage{}
+	filter := Params{
+		Merge: merge,
+	}
 
-	return
+	_, err := store.api.
+		URL("/settings/api/v1/settings/%s", url.PathEscape(scope)).
+		Query(&filter).
+		Get(&settings)
+
+	return settings, err
 }
 
-// ScopeSchema get schema for the scope
-func (store *Settings) ScopeSchema(scope string) (schema *json.RawMessage, err error) {
-	_, err = store.api.
-		URL("/settings/api/v1/schema/%s", url.PathEscape(scope)).
-		Get(&schema)
+// UpdateScopeSettings update settings for a scope.
+func (store *Settings) UpdateScopeSettings(settings *json.RawMessage, scope string) error {
+	_, err := store.api.
+		URL("/settings/api/v1/settings/%s", url.PathEscape(scope)).
+		Put(settings)
 
-	return
+	return err
+}
+
+// ScopeSectionSettings get settings for the scope
+func (store *Settings) ScopeSectionSettings(scope, section string) (*json.RawMessage, error) {
+	settings := &json.RawMessage{}
+	_, err := store.api.
+		URL("/settings/api/v1/settings/%s/%s", url.PathEscape(scope), url.PathEscape(section)).
+		Get(&settings)
+
+	return settings, err
 }
 
 // UpdateScopeSectionSettings update settings for a scope and section combination
@@ -51,34 +67,22 @@ func (store *Settings) UpdateScopeSectionSettings(settings *json.RawMessage, sco
 	return err
 }
 
-// ScopeSectionSettings get settings for the scope
-func (store *Settings) ScopeSectionSettings(scope, section string) (settings *json.RawMessage, err error) {
-	_, err = store.api.
-		URL("/settings/api/v1/settings/%s/%s", url.PathEscape(scope), url.PathEscape(section)).
-		Get(&settings)
-
-	return
-}
-
-// ScopeSettings get settings for the scope
-func (store *Settings) ScopeSettings(scope, merge string) (settings *json.RawMessage, err error) {
-	filter := Params{
-		Merge: merge,
-	}
-
-	_, err = store.api.
-		URL("/settings/api/v1/settings/%s", url.PathEscape(scope)).
-		Query(&filter).
-		Get(&settings)
-
-	return
-}
-
-// UpdateScopeSettings update settings for a scope.
-func (store *Settings) UpdateScopeSettings(settings *json.RawMessage, scope string) error {
+// ScopeSchema get schema for the scope
+func (store *Settings) ScopeSchema(scope string) (*json.RawMessage, error) {
+	schema := &json.RawMessage{}
 	_, err := store.api.
-		URL("/settings/api/v1/settings/%s", url.PathEscape(scope)).
-		Put(settings)
+		URL("/settings/api/v1/schema/%s", url.PathEscape(scope)).
+		Get(&schema)
 
-	return err
+	return schema, err
+}
+
+// SectionSchema get schema for the section
+func (store *Settings) SectionSchema(scope, section string) (*json.RawMessage, error) {
+	schema := &json.RawMessage{}
+	_, err := store.api.
+		URL("/settings/api/v1/schema/%s/%s", url.PathEscape(scope), url.PathEscape(section)).
+		Get(&schema)
+
+	return schema, err
 }


### PR DESCRIPTION
- Restructured functions according to the api reference doc layout.
- Removed named return values and naked returns.
- Renamed variables.