### PR TITLE
Api endpoint/authorizer

### DIFF
--- a/api/authorizer/client.go
+++ b/api/authorizer/client.go
@@ -210,6 +210,15 @@ func (auth *Client) TrustedClientHealthCheck(time *ClientTime) (*ConfigurationEr
 	return configErrors, err
 }
 
+// OAMVersion gets OAM version javascript snippet
+func (auth *Client) OAMVersion(filename string) error {
+	err := auth.api.
+		URL("/authorizer/api/v1/version.js").
+		Download(filename)
+
+	return err
+}
+
 // DeployScriptSessionID get a session id for a deployment script
 func (auth *Client) DeployScriptSessionID(trustedClientID string) (*Session, error) {
 	sessionID := &Session{}

--- a/api/authorizer/client.go
+++ b/api/authorizer/client.go
@@ -170,8 +170,8 @@ func (auth *Client) ExtenderCACertificate(id string) (*CA, error) {
 	return certificate, err
 }
 
-// ExtenderCertificateRevocationList gets authorizer CA's certificate revocation list
-func (auth *Client) ExtenderCertificateRevocationList(filename, id string) error {
+// DownloadExtenderCertificateCRL gets authorizer CA's certificate revocation list
+func (auth *Client) DownloadExtenderCertificateCRL(filename, id string) error {
 	err := auth.api.
 		URL("/authorizer/api/v1/extender/cas/%s/crl", url.PathEscape(id)).
 		Download(filename)
@@ -179,9 +179,9 @@ func (auth *Client) ExtenderCertificateRevocationList(filename, id string) error
 	return err
 }
 
-// ExtenderConfigSessionID get a session id
-func (auth *Client) ExtenderConfigSessionID(trustedClientID string) (*Session, error) {
-	sessionID := &Session{}
+// ExtenderConfigDownloadHandle get a session id
+func (auth *Client) ExtenderConfigDownloadHandle(trustedClientID string) (*DownloadHandle, error) {
+	sessionID := &DownloadHandle{}
 
 	_, err := auth.api.
 		URL("/authorizer/api/v1/extender/conf/%s", url.PathEscape(trustedClientID)).
@@ -200,8 +200,8 @@ func (auth *Client) ExtenderConfig(trustedClientID, sessionID, filename string) 
 }
 
 // TrustedClientHealthCheck test the health of the trusted client connection with the server
-func (auth *Client) TrustedClientHealthCheck(time *ClientTime) (*ConfigurationError, error) {
-	configErrors := &ConfigurationError{}
+func (auth *Client) TrustedClientHealthCheck(time *HealthCheckParams) (*HealthCheckStatus, error) {
+	configErrors := &HealthCheckStatus{}
 
 	_, err := auth.api.
 		URL("/authorizer/api/v1/trusted-clients/health-check").
@@ -210,18 +210,9 @@ func (auth *Client) TrustedClientHealthCheck(time *ClientTime) (*ConfigurationEr
 	return configErrors, err
 }
 
-// OAMVersion gets OAM version javascript snippet
-func (auth *Client) OAMVersion(filename string) error {
-	err := auth.api.
-		URL("/authorizer/api/v1/version.js").
-		Download(filename)
-
-	return err
-}
-
 // DeployScriptSessionID get a session id for a deployment script
-func (auth *Client) DeployScriptSessionID(trustedClientID string) (*Session, error) {
-	sessionID := &Session{}
+func (auth *Client) DeployScriptSessionID(trustedClientID string) (*DownloadHandle, error) {
+	sessionID := &DownloadHandle{}
 
 	_, err := auth.api.
 		URL("/authorizer/api/v1/deploy/%s", url.PathEscape(trustedClientID)).
@@ -230,8 +221,8 @@ func (auth *Client) DeployScriptSessionID(trustedClientID string) (*Session, err
 	return sessionID, err
 }
 
-// DeployScript gets a pre-configured deployment script
-func (auth *Client) DeployScript(trustedClientID, sessionID, filename string) error {
+// DownloadDeployScript gets a pre-configured deployment script
+func (auth *Client) DownloadDeployScript(trustedClientID, sessionID, filename string) error {
 	err := auth.api.
 		URL("/authorizer/api/v1/deploy/%s/%s", url.PathEscape(trustedClientID), url.PathEscape(sessionID)).
 		Download(filename)
@@ -239,8 +230,8 @@ func (auth *Client) DeployScript(trustedClientID, sessionID, filename string) er
 	return err
 }
 
-// PrincipalsCommandScript gets the principals_command.sh script
-func (auth *Client) PrincipalsCommandScript(filename string) error {
+// DownloadPrincipalCommandScript gets the principals_command.sh script
+func (auth *Client) DownloadPrincipalCommandScript(filename string) error {
 	err := auth.api.
 		URL("/authorizer/api/v1/deploy/principals_command.sh").
 		Download(filename)

--- a/api/authorizer/client.go
+++ b/api/authorizer/client.go
@@ -143,3 +143,98 @@ func (auth *Client) SignPrincipalKey(groupID, keyID string, credential *Credenti
 
 	return signature, err
 }
+
+// ExtenderCACertificates gets authorizer's extender CA certificates
+func (auth *Client) ExtenderCACertificates(accessGroupID string) ([]CA, error) {
+	certificates := []CA{}
+	filters := Params{
+		AccessGroupID: accessGroupID,
+	}
+
+	_, err := auth.api.
+		URL("/authorizer/api/v1/extender/cas").
+		Query(&filters).
+		Get(&certificates)
+
+	return certificates, err
+}
+
+// ExtenderCACertificate gets authorizer's extender CA certificate
+func (auth *Client) ExtenderCACertificate(id string) (*CA, error) {
+	certificate := &CA{}
+
+	_, err := auth.api.
+		URL("/authorizer/api/v1/extender/cas/%s", url.PathEscape(id)).
+		Get(&certificate)
+
+	return certificate, err
+}
+
+// ExtenderCertificateRevocationList gets authorizer CA's certificate revocation list
+func (auth *Client) ExtenderCertificateRevocationList(filename, id string) error {
+	err := auth.api.
+		URL("/authorizer/api/v1/extender/cas/%s/crl", url.PathEscape(id)).
+		Download(filename)
+
+	return err
+}
+
+// ExtenderConfigSessionID get a session id
+func (auth *Client) ExtenderConfigSessionID(trustedClientID string) (*Session, error) {
+	sessionID := &Session{}
+
+	_, err := auth.api.
+		URL("/authorizer/api/v1/extender/conf/%s", url.PathEscape(trustedClientID)).
+		Post(nil, &sessionID)
+
+	return sessionID, err
+}
+
+// ExtenderConfig gets a pre-configured extender config
+func (auth *Client) ExtenderConfig(trustedClientID, sessionID, filename string) error {
+	err := auth.api.
+		URL("/authorizer/api/v1/extender/conf/%s/%s", url.PathEscape(trustedClientID), url.PathEscape(sessionID)).
+		Download(filename)
+
+	return err
+}
+
+// TrustedClientHealthCheck test the health of the trusted client connection with the server
+func (auth *Client) TrustedClientHealthCheck(time *ClientTime) (*ConfigurationError, error) {
+	configErrors := &ConfigurationError{}
+
+	_, err := auth.api.
+		URL("/authorizer/api/v1/trusted-clients/health-check").
+		Post(&time, &configErrors)
+
+	return configErrors, err
+}
+
+// DeployScriptSessionID get a session id for a deployment script
+func (auth *Client) DeployScriptSessionID(trustedClientID string) (*Session, error) {
+	sessionID := &Session{}
+
+	_, err := auth.api.
+		URL("/authorizer/api/v1/deploy/%s", url.PathEscape(trustedClientID)).
+		Post(nil, &sessionID)
+
+	return sessionID, err
+}
+
+// DeployScript gets a pre-configured deployment script
+func (auth *Client) DeployScript(trustedClientID, sessionID, filename string) error {
+	err := auth.api.
+		URL("/authorizer/api/v1/deploy/%s/%s", url.PathEscape(trustedClientID), url.PathEscape(sessionID)).
+		Download(filename)
+
+	return err
+}
+
+// PrincipalsCommandScript gets the principals_command.sh script
+func (auth *Client) PrincipalsCommandScript(filename string) error {
+	err := auth.api.
+		URL("/authorizer/api/v1/deploy/principals_command.sh").
+		Download(filename)
+
+	return err
+}

--- a/api/authorizer/model.go
+++ b/api/authorizer/model.go
@@ -24,18 +24,18 @@ type Params struct {
 	Limit         int    `json:"limit,omitempty"`
 }
 
-// ClientTime client time definition
-type ClientTime struct {
+// HealthCheckParams health check params definition
+type HealthCheckParams struct {
 	ClientTime string `json:"client_time,omitempty"`
 }
 
-// ConfigurationError configuration error definition
-type ConfigurationError struct {
+// HealthCheckStatus health check status definition
+type HealthCheckStatus struct {
 	Errors []string `json:"errors,omitempty"`
 }
 
-// Session session definition
-type Session struct {
+// DownloadHandle download handle definition
+type DownloadHandle struct {
 	SessionID string `json:"session_id"`
 }
 

--- a/api/authorizer/model.go
+++ b/api/authorizer/model.go
@@ -24,6 +24,21 @@ type Params struct {
 	Limit         int    `json:"limit,omitempty"`
 }
 
+// ClientTime client time definition
+type ClientTime struct {
+	ClientTime string `json:"client_time,omitempty"`
+}
+
+// ConfigurationError configuration error definition
+type ConfigurationError struct {
+	Errors []string `json:"errors,omitempty"`
+}
+
+// Session session definition
+type Session struct {
+	SessionID string `json:"session_id"`
+}
+
 // Signature signature  definition
 type Signature struct {
 	Signature string `json:"signature"`


### PR DESCRIPTION
Added new endpoints to authorizer client:

- GET `/authorizer/api/v1/extender/cas`
- GET `/authorizer/api/v1/extender/cas/{id}`
- GET `/authorizer/api/v1/extender/cas/{id}/crl`
- POST `/authorizer/api/v1/extender/conf/{trusted_client_id}`
- GET `/authorizer/api/v1/extender/conf/{trusted_client_id}/{session_id}`
- POST `/authorizer/api/v1/trusted-clients/health-check`
- GET `/authorizer/api/v1/version.js`
- POST `/authorizer/api/v1/deploy/{trusted_client_id}`
- GET `/authorizer/api/v1/deploy/{trusted_client_id}/{session_id}`
- GET `/authorizer/api/v1/deploy/principals_command.sh`