### PR TITLE
feat(API): add new endpoints, remove health check endpoint

### DIFF
--- a/api/authorizer/client.go
+++ b/api/authorizer/client.go
@@ -321,12 +321,12 @@ func (auth *Client) ExtenderTrustAnchor() (*TrustAnchor, error) {
 }
 
 // AccessGroups lists all access group
-func (auth *Client) AccessGroups(sortkey, sortdir string, offset, limit int) ([]AccessGroup, error) {
+func (auth *Client) AccessGroups(offset, limit int, sortkey, sortdir string) ([]AccessGroup, error) {
 	filters := Params{
-		Sortkey: sortkey,
-		Sortdir: sortdir,
 		Offset:  offset,
 		Limit:   limit,
+		Sortkey: sortkey,
+		Sortdir: sortdir,
 	}
 	result := accessGroupResult{}
 
@@ -352,21 +352,19 @@ func (auth *Client) CreateAccessGroup(accessGroup *AccessGroup) (string, error) 
 }
 
 // SearchAccessGroup search for access groups
-func (auth *Client) SearchAccessGroup(keywords, sortkey, sortdir string, offset, limit int) ([]AccessGroup, error) {
+func (auth *Client) SearchAccessGroup(offset, limit int, sortkey, sortdir string, search *SearchParams) ([]AccessGroup, error) {
 	filters := Params{
-		Sortkey: sortkey,
-		Sortdir: sortdir,
 		Offset:  offset,
 		Limit:   limit,
+		Sortkey: sortkey,
+		Sortdir: sortdir,
 	}
 	result := accessGroupResult{}
 
 	_, err := auth.api.
 		URL("/authorizer/api/v1/accessgroups/search").
 		Query(&filters).
-		Post(map[string]string{
-			"keywords": keywords,
-		}, &result)
+		Post(search, &result)
 
 	return result.Items, err
 }
@@ -392,12 +390,12 @@ func (auth *Client) UpdateAccessGroup(accessGroupID string, accessGroup *AccessG
 }
 
 // SearchCert search for certificates
-func (auth *Client) SearchCert(sortkey, sortdir string, offset, limit int, cert *APICertificateSearch) ([]APICertificate, error) {
+func (auth *Client) SearchCert(offset, limit int, sortkey, sortdir string, cert *APICertificateSearch) ([]APICertificate, error) {
 	filters := Params{
-		Sortkey: sortkey,
-		Sortdir: sortdir,
 		Offset:  offset,
 		Limit:   limit,
+		Sortkey: sortkey,
+		Sortdir: sortdir,
 	}
 	result := apiCertificateResult{}
 

--- a/api/authorizer/client.go
+++ b/api/authorizer/client.go
@@ -29,7 +29,7 @@ type accessGroupResult struct {
 
 type apiCertificateResult struct {
 	Count int              `json:"count"`
-	Items []ApiCertificate `json:"items"`
+	Items []APICertificate `json:"items"`
 }
 
 // New creates a new authorizer client instance
@@ -284,13 +284,13 @@ func (auth *Client) DownloadWebProxyConfig(trustedClientID, sessionID, filename 
 }
 
 // CertTemplates returns the certificate authentication templates for the service
-func (store *Client) CertTemplates(service string) ([]CertTemplate, error) {
+func (auth *Client) CertTemplates(service string) ([]CertTemplate, error) {
 	result := templatesResult{}
 	filters := Params{
 		Service: service,
 	}
 
-	_, err := store.api.
+	_, err := auth.api.
 		URL("/authorizer/api/v1/cert/templates").
 		Query(&filters).
 		Get(&result)
@@ -299,10 +299,10 @@ func (store *Client) CertTemplates(service string) ([]CertTemplate, error) {
 }
 
 // SSLTrustAnchor returns the SSL trust anchor (PrivX TLS CA certificate)
-func (store *Client) SSLTrustAnchor() (*TrustAnchor, error) {
+func (auth *Client) SSLTrustAnchor() (*TrustAnchor, error) {
 	anchor := &TrustAnchor{}
 
-	_, err := store.api.
+	_, err := auth.api.
 		URL("/authorizer/api/v1/ssl-trust-anchor").
 		Get(&anchor)
 
@@ -310,10 +310,10 @@ func (store *Client) SSLTrustAnchor() (*TrustAnchor, error) {
 }
 
 // ExtenderTrustAnchor returns the extender trust anchor (PrivX TLS CA certificate)
-func (store *Client) ExtenderTrustAnchor() (*TrustAnchor, error) {
+func (auth *Client) ExtenderTrustAnchor() (*TrustAnchor, error) {
 	anchor := &TrustAnchor{}
 
-	_, err := store.api.
+	_, err := auth.api.
 		URL("/authorizer/api/v1/extender-trust-anchor").
 		Get(&anchor)
 
@@ -339,12 +339,12 @@ func (auth *Client) AccessGroups(sortkey, sortdir string, offset, limit int) ([]
 }
 
 // CreateAccessGroup create a access group
-func (store *Client) CreateAccessGroup(accessGroup *AccessGroup) (string, error) {
+func (auth *Client) CreateAccessGroup(accessGroup *AccessGroup) (string, error) {
 	var object struct {
 		ID string `json:"id"`
 	}
 
-	_, err := store.api.
+	_, err := auth.api.
 		URL("/authorizer/api/v1/accessgroups").
 		Post(&accessGroup, &object)
 
@@ -352,7 +352,7 @@ func (store *Client) CreateAccessGroup(accessGroup *AccessGroup) (string, error)
 }
 
 // SearchAccessGroup search for access groups
-func (store *Client) SearchAccessGroup(keywords, sortkey, sortdir string, offset, limit int) ([]AccessGroup, error) {
+func (auth *Client) SearchAccessGroup(keywords, sortkey, sortdir string, offset, limit int) ([]AccessGroup, error) {
 	filters := Params{
 		Sortkey: sortkey,
 		Sortdir: sortdir,
@@ -361,7 +361,7 @@ func (store *Client) SearchAccessGroup(keywords, sortkey, sortdir string, offset
 	}
 	result := accessGroupResult{}
 
-	_, err := store.api.
+	_, err := auth.api.
 		URL("/authorizer/api/v1/accessgroups/search").
 		Query(&filters).
 		Post(map[string]string{
@@ -383,8 +383,8 @@ func (auth *Client) AccessGroup(accessGroupID string) (*AccessGroup, error) {
 }
 
 // UpdateAccessGroup update access group
-func (store *Client) UpdateAccessGroup(accessGroupID string, accessGroup *AccessGroup) error {
-	_, err := store.api.
+func (auth *Client) UpdateAccessGroup(accessGroupID string, accessGroup *AccessGroup) error {
+	_, err := auth.api.
 		URL("/authorizer/api/v1/accessgroups/%s", url.PathEscape(accessGroupID)).
 		Put(accessGroup)
 
@@ -392,7 +392,7 @@ func (store *Client) UpdateAccessGroup(accessGroupID string, accessGroup *Access
 }
 
 // SearchCert search for certificates
-func (store *Client) SearchCert(sortkey, sortdir string, offset, limit int, cert *ApiCertificateSearch) ([]ApiCertificate, error) {
+func (auth *Client) SearchCert(sortkey, sortdir string, offset, limit int, cert *APICertificateSearch) ([]APICertificate, error) {
 	filters := Params{
 		Sortkey: sortkey,
 		Sortdir: sortdir,
@@ -401,7 +401,7 @@ func (store *Client) SearchCert(sortkey, sortdir string, offset, limit int, cert
 	}
 	result := apiCertificateResult{}
 
-	_, err := store.api.
+	_, err := auth.api.
 		URL("/authorizer/api/v1/cert/search").
 		Query(&filters).
 		Post(cert, &result)

--- a/api/authorizer/client.go
+++ b/api/authorizer/client.go
@@ -205,8 +205,8 @@ func (auth *Client) ExtenderConfigDownloadHandle(trustedClientID string) (*Downl
 	return sessionID, err
 }
 
-// ExtenderConfig gets a pre-configured extender config
-func (auth *Client) ExtenderConfig(trustedClientID, sessionID, filename string) error {
+// DownloadExtenderConfig gets a pre-configured extender config
+func (auth *Client) DownloadExtenderConfig(trustedClientID, sessionID, filename string) error {
 	err := auth.api.
 		URL("/authorizer/api/v1/extender/conf/%s/%s", url.PathEscape(trustedClientID), url.PathEscape(sessionID)).
 		Download(filename)
@@ -214,8 +214,8 @@ func (auth *Client) ExtenderConfig(trustedClientID, sessionID, filename string) 
 	return err
 }
 
-// DeployScriptSessionID get a session id for a deployment script
-func (auth *Client) DeployScriptSessionID(trustedClientID string) (*DownloadHandle, error) {
+// DeployScriptDownloadHandle get a session id for a deployment script
+func (auth *Client) DeployScriptDownloadHandle(trustedClientID string) (*DownloadHandle, error) {
 	sessionID := &DownloadHandle{}
 
 	_, err := auth.api.

--- a/api/authorizer/model.go
+++ b/api/authorizer/model.go
@@ -24,6 +24,11 @@ type Params struct {
 	Limit         int    `json:"limit,omitempty"`
 }
 
+// SearchParams search params definition
+type SearchParams struct {
+	Keywords string `json:"keywords,omitempty"`
+}
+
 // APICertificate api certificate definition
 type APICertificate struct {
 	ID               string `json:"id,omitempty"`

--- a/api/authorizer/model.go
+++ b/api/authorizer/model.go
@@ -24,8 +24,8 @@ type Params struct {
 	Limit         int    `json:"limit,omitempty"`
 }
 
-// ApiCertificate api certificate definition
-type ApiCertificate struct {
+// APICertificate api certificate definition
+type APICertificate struct {
 	ID               string `json:"id,omitempty"`
 	Type             string `json:"type,omitempty"`
 	OwnerID          string `json:"owner_id,omitempty"`
@@ -35,8 +35,8 @@ type ApiCertificate struct {
 	Chain            string `json:"chain,omitempty"`
 }
 
-// ApiCertificateSearch api certificate search definition
-type ApiCertificateSearch struct {
+// APICertificateSearch api certificate search definition
+type APICertificateSearch struct {
 	ID             string `json:"id,omitempty"`
 	Type           string `json:"type,omitempty"`
 	KeyID          string `json:"key_id,omitempty"`

--- a/api/authorizer/model.go
+++ b/api/authorizer/model.go
@@ -24,14 +24,48 @@ type Params struct {
 	Limit         int    `json:"limit,omitempty"`
 }
 
-// HealthCheckParams health check params definition
-type HealthCheckParams struct {
-	ClientTime string `json:"client_time,omitempty"`
+// ApiCertificate api certificate definition
+type ApiCertificate struct {
+	ID               string `json:"id,omitempty"`
+	Type             string `json:"type,omitempty"`
+	OwnerID          string `json:"owner_id,omitempty"`
+	Revoked          string `json:"revoked,omitempty"`
+	RevocationReason string `json:"revocation_reason,omitempty"`
+	Cert             string `json:"cert,omitempty"`
+	Chain            string `json:"chain,omitempty"`
 }
 
-// HealthCheckStatus health check status definition
-type HealthCheckStatus struct {
-	Errors []string `json:"errors,omitempty"`
+// ApiCertificateSearch api certificate search definition
+type ApiCertificateSearch struct {
+	ID             string `json:"id,omitempty"`
+	Type           string `json:"type,omitempty"`
+	KeyID          string `json:"key_id,omitempty"`
+	OwnerID        string `json:"owner_id,omitempty"`
+	Subject        string `json:"subject,omitempty"`
+	Issuer         string `json:"issuer,omitempty"`
+	NotBefore      string `json:"not_before,omitempty"`
+	NotAfter       string `json:"not_after,omitempty"`
+	IncludeRevoked bool   `json:"include_revoked,omitempty"`
+	IncludeExpired bool   `json:"include_expired,omitempty"`
+}
+
+// TrustAnchor trust anchor definition
+type TrustAnchor struct {
+	TrustAnchor       string `json:"trust_anchor"`
+	TrustAnchorSHA1   string `json:"trust_anchor_sha1,omitempty"`
+	TrustAnchorSHA256 string `json:"trust_anchor_sha256,omitempty"`
+}
+
+// CertTemplate certification template definition
+type CertTemplate struct {
+	Name              string   `json:"name"`
+	Description       string   `json:"description"`
+	Service           string   `json:"service"`
+	Type              string   `json:"type"`
+	KeyID             string   `json:"key_id,omitempty"`
+	RsaSignatureTypes []string `json:"rsa_signature_types,omitempty"`
+	Principals        []string `json:"principals,omitempty"`
+	Extensions        []string `json:"extensions,omitempty"`
 }
 
 // DownloadHandle download handle definition


### PR DESCRIPTION
Removed `TrustedClientHealthCheck `.
Added new final endpoints:

- POST `/authorizer/api/v1/carrier/conf/{trusted_client_id}`
- GET `/authorizer/api/v1/carrier/conf/{trusted_client_id}/{session_id}`
- POST `/authorizer/api/v1/icap/conf/{trusted_client_id}`
- GET `/authorizer/api/v1/icap/conf/{trusted_client_id}/{session_id}`
- GET `/authorizer/api/v1/cert/templates`
- GET `/authorizer/api/v1/ssl-trust-anchor`
- GET `/authorizer/api/v1/extender-trust-anchor`
- GET `/authorizer/api/v1/accessgroups`
- POST `/authorizer/api/v1/accessgroups`
- POST `/authorizer/api/v1/accessgroups/search`
- GET `/authorizer/api/v1/accessgroups/{id}`
- PUT `/authorizer/api/v1/accessgroups/{id}`
- POST `/authorizer/api/v1/cert/search`