### PR TITLE
fix(API): add missing endpoints

### DIFF
--- a/api/authorizer/client.go
+++ b/api/authorizer/client.go
@@ -426,7 +426,7 @@ func (auth *Client) UpdateAccessGroup(accessGroupID string, accessGroup *AccessG
 
 // DeleteAccessGroup delete a access group
 func (auth *Client) DeleteAccessGroup(accessGroupID string) error {
-	_, err := store.api.
+	_, err := auth.api.
 		URL("/authorizer/api/v1/accessgroups/%s", accessGroupID).
 		Delete()
 

--- a/api/authorizer/client.go
+++ b/api/authorizer/client.go
@@ -263,6 +263,41 @@ func (auth *Client) DownloadCarrierConfig(trustedClientID, sessionID, filename s
 	return err
 }
 
+// WebProxyCACertificates gets authorizer's web proxy CA certificates
+func (auth *Client) WebProxyCACertificates(accessGroupID string) ([]CA, error) {
+	certificates := []CA{}
+	filters := Params{
+		AccessGroupID: accessGroupID,
+	}
+
+	_, err := auth.api.
+		URL("/authorizer/api/v1/icap/cas").
+		Query(&filters).
+		Get(&certificates)
+
+	return certificates, err
+}
+
+// WebProxyCACertificate gets authorizer's web proxy CA certificate
+func (auth *Client) WebProxyCACertificate(id string) (*CA, error) {
+	certificate := &CA{}
+
+	_, err := auth.api.
+		URL("/authorizer/api/v1/icap/cas/%s", url.PathEscape(id)).
+		Get(&certificate)
+
+	return certificate, err
+}
+
+// DownloadWebProxyCertificateCRL gets authorizer CA's certificate revocation list
+func (auth *Client) DownloadWebProxyCertificateCRL(filename, id string) error {
+	err := auth.api.
+		URL("/authorizer/api/v1/icap/cas/%s/crl", url.PathEscape(id)).
+		Download(filename)
+
+	return err
+}
+
 // WebProxySessionDownloadHandle get a session id for a web proxy config
 func (auth *Client) WebProxySessionDownloadHandle(trustedClientID string) (*DownloadHandle, error) {
 	sessionID := &DownloadHandle{}
@@ -385,6 +420,15 @@ func (auth *Client) UpdateAccessGroup(accessGroupID string, accessGroup *AccessG
 	_, err := auth.api.
 		URL("/authorizer/api/v1/accessgroups/%s", url.PathEscape(accessGroupID)).
 		Put(accessGroup)
+
+	return err
+}
+
+// DeleteAccessGroup delete a access group
+func (store *Client) DeleteAccessGroup(accessGroupID string) error {
+	_, err := store.api.
+		URL("/authorizer/api/v1/accessgroups/%s", accessGroupID).
+		Delete()
 
 	return err
 }

--- a/api/authorizer/client.go
+++ b/api/authorizer/client.go
@@ -425,7 +425,7 @@ func (auth *Client) UpdateAccessGroup(accessGroupID string, accessGroup *AccessG
 }
 
 // DeleteAccessGroup delete a access group
-func (store *Client) DeleteAccessGroup(accessGroupID string) error {
+func (auth *Client) DeleteAccessGroup(accessGroupID string) error {
 	_, err := store.api.
 		URL("/authorizer/api/v1/accessgroups/%s", accessGroupID).
 		Delete()

--- a/api/authorizer/client.go
+++ b/api/authorizer/client.go
@@ -279,20 +279,20 @@ func (auth *Client) WebProxyCACertificates(accessGroupID string) ([]CA, error) {
 }
 
 // WebProxyCACertificate gets authorizer's web proxy CA certificate
-func (auth *Client) WebProxyCACertificate(id string) (*CA, error) {
+func (auth *Client) WebProxyCACertificate(trustedClientID string) (*CA, error) {
 	certificate := &CA{}
 
 	_, err := auth.api.
-		URL("/authorizer/api/v1/icap/cas/%s", url.PathEscape(id)).
+		URL("/authorizer/api/v1/icap/cas/%s", url.PathEscape(trustedClientID)).
 		Get(&certificate)
 
 	return certificate, err
 }
 
 // DownloadWebProxyCertificateCRL gets authorizer CA's certificate revocation list
-func (auth *Client) DownloadWebProxyCertificateCRL(filename, id string) error {
+func (auth *Client) DownloadWebProxyCertificateCRL(filename, trustedClientID string) error {
 	err := auth.api.
-		URL("/authorizer/api/v1/icap/cas/%s/crl", url.PathEscape(id)).
+		URL("/authorizer/api/v1/icap/cas/%s/crl", url.PathEscape(trustedClientID)).
 		Download(filename)
 
 	return err


### PR DESCRIPTION
Added missing endpoints to the authorizer client:

- GET `/authorizer/api/v1/icap/cas`
- GET `/authorizer/api/v1/icap/cas/{id}`
- GET `/authorizer/api/v1/icap/cas/{id}/crl`
- DELETE `/authorizer/api/v1/accessgroups/{id}`