### PR TITLE
feat(API): add auth client to sdk

### DIFF
--- a/api/auth/client.go
+++ b/api/auth/client.go
@@ -1,0 +1,33 @@
+//
+// Copyright (c) 2021 SSH Communications Security Inc.
+//
+// All rights reserved.
+//
+
+package auth
+
+import (
+	"github.com/SSHcom/privx-sdk-go/restapi"
+)
+
+// Auth is a auth client instance.
+type Auth struct {
+	api restapi.Connector
+}
+
+// New creates a new auth client instance, using the
+// argument SDK API client.
+func New(api restapi.Connector) *Auth {
+	return &Auth{api: api}
+}
+
+// AuthStatus get microservice status
+func (store *Auth) AuthStatus() (*ServiceStatus, error) {
+	status := &ServiceStatus{}
+
+	_, err := store.api.
+		URL("/auth/api/v1/status").
+		Get(status)
+
+	return status, err
+}

--- a/api/auth/model.go
+++ b/api/auth/model.go
@@ -1,0 +1,28 @@
+//
+// Copyright (c) 2021 SSH Communications Security Inc.
+//
+// All rights reserved.
+//
+
+package auth
+
+import "time"
+
+// KeyValue key value definition
+type KeyValue struct {
+	Key   string `json:"k"`
+	Value string `json:"v"`
+}
+
+// ServiceStatus auth service status definition
+type ServiceStatus struct {
+	Variant       string     `json:"variant,omitempty"`
+	Version       string     `json:"version,omitempty"`
+	ApiVersion    string     `json:"api_version,omitempty"`
+	Status        string     `json:"status,omitempty"`
+	StatusMessage string     `json:"status_message,omitempty"`
+	ApplicationID string     `json:"app_id,omitempty"`
+	ServerMode    string     `json:"server-mode,omitempty"`
+	StatusDetails []KeyValue `json:"status_details,omitempty"`
+	StartTime     time.Time  `json:"start_time,omitempty"`
+}

--- a/api/auth/model.go
+++ b/api/auth/model.go
@@ -18,7 +18,7 @@ type KeyValue struct {
 type ServiceStatus struct {
 	Variant       string     `json:"variant,omitempty"`
 	Version       string     `json:"version,omitempty"`
-	ApiVersion    string     `json:"api_version,omitempty"`
+	APIVersion    string     `json:"api_version,omitempty"`
 	Status        string     `json:"status,omitempty"`
 	StatusMessage string     `json:"status_message,omitempty"`
 	ApplicationID string     `json:"app_id,omitempty"`


### PR DESCRIPTION
Added new client, auth, to sdk.
Added a new endpoint to auth:

- GET `/auth/api/v1/status`