### PR TITLE
Add ueba status and internal status endpoints to GO SDK

### DIFF
--- a/api/connectionmanager/client.go
+++ b/api/connectionmanager/client.go
@@ -364,3 +364,25 @@ func (store *ConnectionManager) ConnectionCounts(timerange TimeRange) (Connectio
 
 	return count, err
 }
+
+// UebaStatus Get Ueba service status
+func (store *ConnectionManager) UebaStatus() (ServiceStatus, error) {
+	uebaStatus := ServiceStatus{}
+
+	_, err := store.api.
+		URL("/connection-manager/api/v1/ueba/status").
+		Get(&uebaStatus)
+
+	return uebaStatus, err
+}
+
+// UebaInternalStatus Get Ueba microservice internal status
+func (store *ConnectionManager) UebaInternalStatus() (UebaInternalStatus, error) {
+	uebaInternalStatus := UebaInternalStatus{}
+
+	_, err := store.api.
+		URL("/connection-manager/api/v1/ueba/status/internal").
+		Get(&uebaInternalStatus)
+
+	return uebaInternalStatus, err
+}

--- a/api/connectionmanager/model.go
+++ b/api/connectionmanager/model.go
@@ -238,12 +238,12 @@ type KeyValue struct {
 // ServiceStatus ueba service status definition
 type ServiceStatus struct {
 	Variant       string     `json:"variant,omitempty"`
-	Version       string     `json:"version,omitempty"`
-	APIVersion    string     `json:"api_version,omitempty"`
-	Status        string     `json:"status,omitempty"`
+	Version       string     `json:"version"`
+	APIVersion    string     `json:"api_version"`
+	Status        string     `json:"status"`
 	StatusMessage string     `json:"status_message,omitempty"`
 	ApplicationID string     `json:"app_id,omitempty"`
 	ServerMode    string     `json:"server-mode,omitempty"`
 	StatusDetails []KeyValue `json:"status_details,omitempty"`
-	StartTime     time.Time  `json:"start_time,omitempty"`
+	StartTime     time.Time  `json:"start_time"`
 }

--- a/api/connectionmanager/model.go
+++ b/api/connectionmanager/model.go
@@ -214,3 +214,36 @@ type ConnectionCount struct {
 type IDstruct struct {
 	ID string `json:"id"`
 }
+
+type UebaInternalModelInstance struct {
+	ID                string `json:"id" validate:"uuid,omitempty"`
+	FeatureConfigName string `json:"feature_config_name"`
+	Status            string `json:"status"`
+	Created           string `json:"created"`
+}
+
+type UebaInternalStatus struct {
+	TrainingStatus      string                      `json:"training_status"`
+	InferenceStatus     string                      `json:"inference_status"`
+	DatasetID           string                      `json:"dataset_id" validate:"uuid,omitempty"`
+	ModelInstanceStatus []UebaInternalModelInstance `json:"model_instance_status"`
+}
+
+// KeyValue key value definition
+type KeyValue struct {
+	Key   string `json:"k"`
+	Value string `json:"v"`
+}
+
+// ServiceStatus ueba service status definition
+type ServiceStatus struct {
+	Variant       string     `json:"variant,omitempty"`
+	Version       string     `json:"version,omitempty"`
+	APIVersion    string     `json:"api_version,omitempty"`
+	Status        string     `json:"status,omitempty"`
+	StatusMessage string     `json:"status_message,omitempty"`
+	ApplicationID string     `json:"app_id,omitempty"`
+	ServerMode    string     `json:"server-mode,omitempty"`
+	StatusDetails []KeyValue `json:"status_details,omitempty"`
+	StartTime     time.Time  `json:"start_time,omitempty"`
+}

--- a/api/connectionmanager/model.go
+++ b/api/connectionmanager/model.go
@@ -216,7 +216,7 @@ type IDstruct struct {
 }
 
 type UebaInternalModelInstance struct {
-	ID                string `json:"id" validate:"uuid,omitempty"`
+	ID                string `json:"id" validate:"uuid"`
 	FeatureConfigName string `json:"feature_config_name"`
 	Status            string `json:"status"`
 	Created           string `json:"created"`


### PR DESCRIPTION
These were missed out in earlier commit as the API reference [page](https://privx.docs.ssh.com/reference/ueba-status) for this was empty.