### PR TITLE
Cookie support

### DIFF
--- a/oauth/authtoken.go
+++ b/oauth/authtoken.go
@@ -21,3 +21,8 @@ func WithToken(token string) restapi.Authorizer {
 func (auth *tAuthExplicit) AccessToken() (string, error) {
 	return auth.string, nil
 }
+
+func (auth *tAuthExplicit) Cookie() string {
+	// Session cookies not suppoted for explicit auth
+	return ""
+}

--- a/oauth/opts.go
+++ b/oauth/opts.go
@@ -112,3 +112,10 @@ func UseEnvironment() Option {
 		return auth
 	}
 }
+
+func UseCookies() Option {
+	return func(auth *tAuth) *tAuth {
+		auth.useCookies = true
+		return auth
+	}
+}

--- a/oauth/types.go
+++ b/oauth/types.go
@@ -30,15 +30,16 @@ func (token *AccessToken) isInvalid() bool {
 // tAuth authorizer client
 type tAuth struct {
 	*sync.Cond
-	access  string
-	secret  string
-	digest  string
-	client  restapi.Connector
-	token   *AccessToken
-	pending bool
+	access     string
+	secret     string
+	digest     string
+	client     restapi.Connector
+	token      *AccessToken
+	useCookies bool
+	cookie     string
+	pending    bool
 }
 
-//
 func newAuth(client restapi.Connector, opts ...Option) *tAuth {
 	auth := &tAuth{
 		Cond:   sync.NewCond(new(sync.Mutex)),
@@ -70,6 +71,10 @@ func (auth *tAuth) synchronized(f func() error) (err error) {
 	}
 
 	return
+}
+
+func (auth *tAuth) Cookie() string {
+	return auth.cookie
 }
 
 // tClientID is a pair of unique client id and redirect uri

--- a/restapi/client.go
+++ b/restapi/client.go
@@ -85,6 +85,10 @@ func (client *tClient) do(req *http.Request) (*http.Response, error) {
 			return nil, err
 		}
 		req.Header.Set("Authorization", token)
+
+		if cookie := client.auth.Cookie(); cookie != "" {
+			req.Header.Set("Cookie", cookie)
+		}
 	}
 	req.Header.Set("User-Agent", UserAgent)
 

--- a/restapi/types.go
+++ b/restapi/types.go
@@ -38,6 +38,7 @@ type CURL interface {
 // Authorizer provides access token for REST API client
 type Authorizer interface {
 	AccessToken() (string, error)
+	Cookie() string
 }
 
 const (


### PR DESCRIPTION
Adds an oauth option UseCookies() to enable using a cookie for subsequent requests. Cookies are not currently supported for the explicit auth method.

This is for feature parity with the Python SDK.